### PR TITLE
Add a download link for `perovskites` export archive

### DIFF
--- a/docs/pages/2019_MARVEL_Psik_MaX/notebooks/querybuilder-template.ipynb
+++ b/docs/pages/2019_MARVEL_Psik_MaX/notebooks/querybuilder-template.ipynb
@@ -767,7 +767,10 @@
     "In this part of the tutorial, we will focus on how to systematically retrieve, query and analyze the results of\n",
     "multiple calculations using AiiDA. We know you’re able to do this yourself, but to save time, a set of calculations\n",
     "have already been done with AiiDA for you on 57 perovskites, using three different pseudopotential families (LDA,\n",
-    "PBE and PBESOL, all from GBRV 1.2). These calculations are spin-polarized (without spin-orbit coupling), use a Gaussian smearing and perform a variable-cell relaxation of the full unit cell. The idea of this part of the tutorial is to “screen” for magnetic and metallic perovskites in a “high-throughput” way. As you learned in the first part of the tutorial, AiiDA allows to organize calculations in groups. Once more check the list of groups in your database by typing:"
+    "PBE and PBESOL, all from GBRV 1.2).\n\n",
+    "Note: if you are not following the tutorial on the official virtual machine that comes with this data, but you are working with your own database, you first have to import this archive (download it here: https://drive.google.com/open?id=1eqJaJr7q1VsYYvGxqHxmDN7gBMs534rz) using `verdi import`",
+    "\n\n",
+    "These calculations are spin-polarized (without spin-orbit coupling), use a Gaussian smearing and perform a variable-cell relaxation of the full unit cell. The idea of this part of the tutorial is to “screen” for magnetic and metallic perovskites in a “high-throughput” way. As you learned in the first part of the tutorial, AiiDA allows to organize calculations in groups. Once more check the list of groups in your database by typing:"
    ]
   },
   {


### PR DESCRIPTION
Fixes #34 

The query builder part of the tutorial depends on some data being
present in the database. This data would be imported for the virtual
machine so it would be available to users during the tutorial. Importing
the archive was not enough, as it relied on some extras being set, which
at the time were not exportable. Therefore a script had to be run after
importing that would set these extras and recreated the groups for the
pseudo potential families. The archive was not made available publicly
which means that users running the tutorial in their own environment and
database could not perform this last section.

These problems have now been addressed:

 * The archive was migrated from v0.3 to v0.4 with `aiida-core==1.0.0b3`
 * The migrated archive was imported into a clean database
 * The pseudo potential family groups were recreated
 * The extras were set on the calculations and structure nodes:
   - Structure formula was set on the calculation node
   - `A` and `B` element of `ABO3` perovskite formule set on structure
 * The 3 pseudo family groups and 3 calculation groups were exported.
   - Only direct inputs and outputs of the calculations were included

The text in the query builder notebook has been updated to include a
link to this archive. For now this is a dropbox link, but should be
replaced with a permanent link once the archive is fully tested and
confirmed to be correct.