### PR TITLE
Reinsert the footnotes in the right places

### DIFF
--- a/docs/pages/2019_MARVEL_Psik_MaX/sections/appendix_workflow_logic.rst
+++ b/docs/pages/2019_MARVEL_Psik_MaX/sections/appendix_workflow_logic.rst
@@ -128,36 +128,3 @@ A possible way to visualize it is presented in :numref:`fig_convpressure` obtain
    The bottom plot is a zoom near the minimum.
    The dots represent the (volume,energy) points obtained from Quantum ESPRESSO, and the numbers indicate at which iteration they were obtained.
    The parabolas represent the parabolic fits used in the algorithm; the minimum of the parabola is represented with a small cross, in correspondence of the vertical lines, used as the volume for the following step.
-
-
-[1] The string provided to the ``DataFactory`` encodes both the location
-and the name of the required class according to some specific rules.
-
-[2] if you set the structure incorrectly, for example with overlapping
-atoms, it is very likely that any DFT code will fail!
-
-[3] We purposefully do not provide advanced commands for crystal
-structure manipulation in AiiDA, because python packages that accomplish
-such tasks already exist (such as ASE or pymatgen).
-
-[4] https://aiidateam.github.io/aiida-registry/
-
-[5] http://www.quantum-espresso.org/wp-content/uploads/Doc/INPUT_PW.html
-
-[6]
-http://aiida-core.readthedocs.io/en/latest/plugins/quantumespresso/pw.html
-
-[7] However, to avoid duplication of KpointsData, you should first learn
-how to query the database, therefore we will ignore this duplication
-issue for now.
-
-[8] For JobCalculations (i.e., calculations that are submitted to a
-remote computer through a scheduler) there is an additional 'Job state'
-(last column of the output of ``verdi calculation list``) that can
-either be FINISHED if all went well, or one of the possible failure
-states (FAILED, PARSINGFAILED, SUBMISSIONFAILED, RETRIEVALFAILED). These
-states are represented as a Finished state (third column of
-``verdi calculation list``, with a zero/non-zero error code depending if
-they finished/did not finish correctly). This latter state is more
-general than just JobCalculations and also applies to workflows, as we
-will see later in the tutorial.

--- a/docs/pages/2019_MARVEL_Psik_MaX/sections/calculations.rst
+++ b/docs/pages/2019_MARVEL_Psik_MaX/sections/calculations.rst
@@ -13,9 +13,8 @@ automate this procedure considerably. For computing the DFT energy of
 the silicon crystal (with a PBE functional) we will use Quantum
 ESPRESSO , in particular the PWscf code (``pw.x``). Besides the
 AiiDA-core package, a number of plugins exist for many different codes.
-These are listed in the `AiiDA plugin
-registry <https://aiidateam.github.io/aiida-registry/>`__\ [4]. In
-particular, the “aiida-quantumespresso” plugin (already installed in
+These are listed in the `AiiDA plugin registry <https://aiidateam.github.io/aiida-registry/>`_.
+In particular, the ``aiida-quantumespresso`` plugin (already installed in
 your machine) provides a very extensive set of plugins, covering most
 (if not all) the functionalities of the underlying codes.
 
@@ -145,10 +144,10 @@ Preparation of inputs
 
 Quantum ESPRESSO requires an input file containing Fortran namelists and
 variables, plus some cards sections (the documentation is available
-`online <https://www.quantum-espresso.org/Doc/INPUT_PW.html>`__\ [5]).
+`here <https://www.quantum-espresso.org/Doc/INPUT_PW.html>`_).
 The Quantum ESPRESSO plugin of AiiDA requires quite a few nodes in
 input, which are also documented
-`online <https://aiida-quantumespresso.readthedocs.io/en/stable/user_guide/calculation_plugins/pw.html>`__\ [6].
+`online <https://aiida-quantumespresso.readthedocs.io/en/stable/user_guide/calculation_plugins/pw.html>`_.
 Here we will instruct our calculation with a minimal configuration for
 computing the energy of silicon. We need:
 
@@ -167,7 +166,7 @@ code that you executed previously, you will create duplicated
 information in the database (i.e. every time you will execute the
 script, you will create another StructureData, another KpointsData,
 ...). In fact, you already have the opportunity to re-use an already
-existing structure.[7] Use therefore a combination of the bash command
+existing structure [#f1]_. Use therefore a combination of the bash command
 ``verdi data structure list`` and of the shell command ``load_node()``
 to get an object representing the structure created earlier.
 
@@ -269,7 +268,7 @@ database) the input of the graph shown bellow, whereas the outputs will
 be created later by the daemon.
 
 .. figure:: include/images/verdi_graph/si/graph-full.png
-   :alt: 
+   :alt:
 
 In order to check how AiiDA creates the actual input files for the
 calculation, we can perform a *dry run* of the submission process, to
@@ -370,9 +369,7 @@ by the PWscf calculation).
 
 By now, it is possible that the calculation you submitted has already
 finished, and therefore that you don’t see any calculation in the
-output. In fact, by default, the command only prints calculations that
-are still being handled by the daemon, i.e. those with a state that is
-not ``FINISHED`` yet[8].
+output. In fact, by default, the command only prints calculations that are still active [#f2]_.
 
 To see also (your) calculations that have finished (and limit those only
 to the one created in the past day), use instead
@@ -534,3 +531,9 @@ Since the name of this output dictionary node is an implementation
 detail of each plugin, AiiDA provides the shortcut ``calculation.res``
 where the developers can indicate what they think is the result of the
 calculation.
+
+
+.. rubric:: Footnotes
+
+.. [#f1] However, to avoid duplication of KpointsData, you should first learn how to query the database, therefore we will ignore this duplication issue for now.
+.. [#f2] A process is considered active if it is either ``Created``, ``Running`` or ``Waiting``. If a process is no longer active, but terminatd, it will have a state ``Finished``, ``Killed`` or ``Excepted``.

--- a/docs/pages/2019_MARVEL_Psik_MaX/sections/verdi_shell.rst
+++ b/docs/pages/2019_MARVEL_Psik_MaX/sections/verdi_shell.rst
@@ -270,7 +270,7 @@ If you make a mistake, start over from
 ``structure = StructureData(cell=the_cell)``, or equivalently use
 ``structure.clear_kinds()`` to remove all kinds (atomic species) and sites.
 Alternatively, AiiDA structures can also be converted directly from ASE
-structures using
+structures [#f1]_ using
 
 .. code:: python
 
@@ -414,3 +414,8 @@ the database with
 .. code:: console
 
     verdi data upf listfamilies
+
+
+.. rubric:: Footnotes
+
+.. [#f1] We purposefully do not provide advanced commands for crystal structure manipulation in AiiDA, because python packages that accomplish such tasks already exist (such as ASE or pymatgen).


### PR DESCRIPTION
Fixes #38 

The automatic conversion from LaTeX had placed all the footnotes in the
last appendix. Some were replaced by direct links so were no longer
relevant.