### PR TITLE
Section 6: second run-through

### DIFF
--- a/docs/pages/2019_MARVEL_Psik_MaX/notebooks/querybuilder-template.ipynb
+++ b/docs/pages/2019_MARVEL_Psik_MaX/notebooks/querybuilder-template.ipynb
@@ -379,7 +379,7 @@
     " Node          | 10273 \n",
     " StructureData | 271   \n",
     " KpointsData   | 953   \n",
-    " ParameterData | 2922  \n",
+    " Dict          | 2922  \n",
     " UpfData       | 85    \n",
     " Code          | 10"
    ]

--- a/docs/pages/2019_MARVEL_Psik_MaX/scripts/create_rescale.py
+++ b/docs/pages/2019_MARVEL_Psik_MaX/scripts/create_rescale.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction
 
 
@@ -48,9 +49,7 @@ def rescale(structure, scale):
     """
     from aiida import orm
 
-    the_ase = structure.get_ase()
-    new_ase = the_ase.copy()
-    new_ase.set_cell(the_ase.get_cell() * float(scale), scale_atoms=True)
-    new_structure = orm.StructureData(ase=new_ase)
+    ase = structure.get_ase()
+    ase.set_cell(ase.get_cell() * float(scale), scale_atoms=True)
 
-    return new_structure
+    return orm.StructureData(ase=ase)

--- a/docs/pages/2019_MARVEL_Psik_MaX/scripts/equation_of_states.py
+++ b/docs/pages/2019_MARVEL_Psik_MaX/scripts/equation_of_states.py
@@ -1,67 +1,59 @@
+# -*- coding: utf-8 -*-
+from aiida.engine import WorkChain, ToContext, calcfunction
+from aiida.orm import Code, Dict, Float, Str, StructureData
+from aiida.plugins import CalculationFactory
+
 from create_rescale import create_diamond_fcc, rescale
 from common_wf import generate_scf_input_params
-from aiida.work.workchain import WorkChain, ToContext
-from aiida.work.run import run, submit
-from aiida.orm.data.base import Str, Float
-from aiida.orm import CalculationFactory, DataFactory
 
 PwCalculation = CalculationFactory('quantumespresso.pw')
-
 scale_facs = (0.96, 0.98, 1.0, 1.02, 1.04)
-labels = ["c1", "c2", "c3", "c4", "c5"]
+labels = ['c1', 'c2', 'c3', 'c4', 'c5']
+
+
+@calcfunction
+def get_eos_data(**kwargs):
+    eos = [(result.dict.volume, result.dict.energy, result.dict.energy_units) for label, result in kwargs.items()]
+    return Dict(dict={'eos': eos})
+
 
 class EquationOfStates(WorkChain):
+
     @classmethod
     def define(cls, spec):
         super(EquationOfStates, cls).define(spec)
-        spec.input("element", valid_type=Str)
-        spec.input("code", valid_type=Str)
-        spec.input("pseudo_family", valid_type=Str)
+        spec.input('code', valid_type=Code)
+        spec.input('element', valid_type=Str)
+        spec.input('pseudo_family', valid_type=Str)
+        spec.output('initial_structure', valid_type=StructureData)
+        spec.output('eos', valid_type=Dict)
         spec.outline(
-            cls.run_pw,
-            cls.return_results,
+            cls.run_eos,
+            cls.results,
         )
 
-    def run_pw(self):
-        print "Workchain node identifiers: {}".format(self.calc)
-        #Instantiate a JobCalc process and create basic structure
-        JobCalc = PwCalculation.process()
-        self.ctx.s0 = create_diamond_fcc(Str(self.inputs.element))
-        self.ctx.eos_names = []
+    def run_eos(self):
+        # Create basic structure and attach it as an output
+        initial_structure = create_diamond_fcc(self.inputs.element)
+        self.out('initial_structure', initial_structure)
 
-        calcs = {}
+        calculations = {}
+
         for label, factor in zip(labels, scale_facs):
-            s = rescale(self.ctx.s0,Float(factor))
-            inputs = generate_scf_input_params(s, str(self.inputs.code), self.inputs.pseudo_family)
-            print "Running a scf for {} with scale factor {}".format(self.inputs.element, factor)
-            future = submit(JobCalc, **inputs)
-            calcs[label] = future
 
-        # Ask the workflow to continue when the results are ready and store them
-        # in the context
-        return ToContext(**calcs)
+            structure = rescale(initial_structure, Float(factor))
+            inputs = generate_scf_input_params(structure, self.inputs.code, self.inputs.pseudo_family)
 
-    def return_results(self):
-        eos = []
-        for label in labels:
-            eos.append(get_info(self.ctx[label].get_outputs_dict()))
+            self.report('Running an SCF calculation for {} with scale factor {}'.format(self.inputs.element, factor))
+            future = self.submit(PwCalculation, **inputs)
+            calculations[label] = future
 
-        #Return information to plot the EOS
-        ParameterData = DataFactory("parameter")
-        retdict = {
-                'initial_structure': self.ctx.s0,
-                'result': ParameterData(dict={'eos_data': eos})
-           }
-        for link_name, node in retdict.iteritems():
-            self.out(link_name, node)
+        # Ask the workflow to continue when the results are ready and store them in the context
+        return ToContext(**calculations)
 
-def get_info(calc_results):
-    return (calc_results['output_parameters'].dict.volume,
-            calc_results['output_parameters'].dict.energy,
-            calc_results['output_parameters'].dict.energy_units)
+    def results(self):
+        inputs = {label: self.ctx[label].get_outgoing().get_node_by_label('output_parameters') for label in labels}
+        eos = get_eos_data(**inputs)
 
-def run_eos(element="Si", code='qe-pw-6.2.1@localhost', pseudo_family='GBRV_lda'):
-    return run(EquationOfStates, element=Str(element), code=Str(code), pseudo_family=Str(pseudo_family))
-
-if __name__ == '__main__':
-    run_eos()
+        # Attach Equation of State results as output node to be able to plot the EOS later
+        self.out('eos', eos)

--- a/docs/pages/2019_MARVEL_Psik_MaX/scripts/plot_calculation_results.py
+++ b/docs/pages/2019_MARVEL_Psik_MaX/scripts/plot_calculation_results.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import sys
 import numpy as np
 from argparse import ArgumentParser

--- a/docs/pages/2019_MARVEL_Psik_MaX/scripts/plot_convergence_pressure.py
+++ b/docs/pages/2019_MARVEL_Psik_MaX/scripts/plot_convergence_pressure.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from aiida.orm import load_node
 
 
@@ -6,7 +7,7 @@ def parabola(x, a, b, c):
 
 
 def show_parabola_results(pk):
-    out_p = load_node(pk).out.steps.get_dict()
+    out_p = load_node(pk).outputs.steps.get_dict()
 
     step0 = out_p['step0']
     steps = out_p['steps']

--- a/docs/pages/2019_MARVEL_Psik_MaX/scripts/pressure_convergence.py
+++ b/docs/pages/2019_MARVEL_Psik_MaX/scripts/pressure_convergence.py
@@ -1,69 +1,75 @@
-from aiida.orm import CalculationFactory, DataFactory
-from aiida.orm import Float, Str, StructureData
-from aiida.engine import run, submit, WorkChain, ToContext, while_
-from common_wf import generate_scf_input_params
-from create_rescale import rescale, create_diamond_fcc
+# -*- coding: utf-8 -*-
+from aiida.engine import WorkChain, ToContext, while_, calcfunction, workfunction
+from aiida.orm import Code, Float, Str, StructureData
+from aiida.plugins import CalculationFactory, DataFactory
 
+from common_wf import generate_scf_input_params
+from create_rescale import rescale
+
+Dict = DataFactory('dict')
+KpointsData = DataFactory('array.kpoints')
 PwCalculation = CalculationFactory('quantumespresso.pw')
 
 
-def run_eos(structure, element="Si", code='qe-pw-6.2.1@localhost', pseudo_family='GBRV_lda'):
-    return run(PressureConvergence, structure=structure, code=Str(code), pseudo_family=Str(pseudo_family), volume_tolerance=Float(0.1))
+def get_energy_first_derivative(stress):
+    """Return the energy first derivative from the stress.
 
-
-# Set up the factories
-Dict = DataFactory('dict')
-ParameterData = DataFactory('parameter')
-KpointsData = DataFactory('array.kpoints')
-
-
-def get_first_deriv(stress):
-    """
-    Return the energy first derivative from the stress
+    :param stress: the stress tensor in GPa
+    :return: first derivative of the energy in eV/Å^3
     """
     from numpy import trace
 
     GPa_to_eV_over_ang3 = 1. / 160.21766208
 
     # Get the pressure (GPa)
-    p = trace(stress) / 3.
+    pressure = trace(stress) / 3.
 
-    # Pressure is -dE/dV; moreover p in kbar, we need to convert it to eV/angstrom^3 to be consistent
-    dE = -p * GPa_to_eV_over_ang3
+    # Pressure is -dE/dV; moreover p in kbar, we need to convert it to eV/Å^3 to be consistent
+    dE = -pressure * GPa_to_eV_over_ang3
+
     return dE
 
 
 def get_volume_energy_and_derivative(output_parameters):
-    """
-    Given the output parameters of the pw calculation,
-    return the volume (ang^3), the energy (eV), and the energy
-    derivative (eV/ang^3)
+    """Return the volume, energy and energy derivative for given `PwCalculation` output parameters.
+
+    Volume is in Å^3, energy in eV and energy derivative eV/Å^3
+
+    :param output_parameters: the `output_parameters` `Dict` result node of a `PwCalculation`
+    :return: tuple with volume, energy and energy derivative
     """
     V = output_parameters.dict.volume
     E = output_parameters.dict.energy
-    dE = get_first_deriv(output_parameters.dict.stress)
+    dE = get_energy_first_derivative(output_parameters.dict.stress)
 
-    return (V, E, dE)
+    return V, E, dE
 
 
-def get_second_derivative(outp1, outp2):
+def get_energy_second_derivative(output_parameters_one, output_parameters_two):
+    """Return second derivative of the energy with respect to the volume given the results of two `PwCalculations`.
+
+    The derivate is computed using the finite differences method.
+
+    :param output_parameters_one: the `output_parameters` `Dict` result node of the first `PwCalculation`
+    :param output_parameters_two: the `output_parameters` `Dict` result node of the second `PwCalculation`
+    :return: the second derivative of the energy with respect to the volume
     """
-    Given the output parameters of the two pw calculations,
-    return the second derivative obtained from finite differences
-    from the pressure of the two calculations (eV/ang^6)
-    """
-    dE1 = get_first_deriv(outp1.dict.stress)
-    dE2 = get_first_deriv(outp2.dict.stress)
-    V1 = outp1.dict.volume
-    V2 = outp2.dict.volume
+    dE1 = get_energy_first_derivative(output_parameters_one.dict.stress)
+    dE2 = get_energy_first_derivative(output_parameters_two.dict.stress)
+    V1 = output_parameters_one.dict.volume
+    V2 = output_parameters_two.dict.volume
+
     return (dE2 - dE1) / (V2 - V1)
 
 
-def get_abc(V, E, dE, ddE):
-    """
-    Given the volume, energy, energy first derivative and energy
-    second derivative, return the a,b,c coefficients of
-    a parabola E = a*V^2 + b*V + c
+def get_parabola_coefficients(V, E, dE, ddE):
+    """Return coefficients of a parabola fit to E = a*V^2 + b*V + c for the given volume and energy.
+
+    :param V: volume in Å^3
+    :param E: energy in eV
+    :param dE: the first derivative of the energy with respect to the volume
+    :param ddE: the second derivative of the energy with respect to the volume
+    :return: coefficients a, b and c
     """
     a = ddE / 2.
     b = dE - ddE * V
@@ -72,28 +78,66 @@ def get_abc(V, E, dE, ddE):
     return a, b, c
 
 
-def get_structure(original_structure, new_volume):
-    """
-    Given a structure and a new volume, rescale the structure to the new volume
-    """
-    initial_volume = original_structure.get_cell_volume()
+@workfunction
+def get_structure(structure, step_data=None):
+    """Return a scaled version of the given structure, where the new volume is determined by the given step data."""
+    initial_volume = structure.get_cell_volume()
+
+    if step_data is None:
+        new_volume = initial_volume + 4.  # In Å^3
+    else:
+        # Minimum of a parabola
+        new_volume = -step_data.dict.b / 2. / step_data.dict.a
+
     scale_factor = (new_volume / initial_volume)**(1. / 3.)
-    scaled_structure = rescale(original_structure, Float(scale_factor))
+    scaled_structure = rescale(structure, Float(scale_factor))
     return scaled_structure
 
 
+@calcfunction
+def get_step_data(parameters_first, parameters_second=None):
+    """Generate a dictionary with the step parameters from the output parameters of a completed `PwCalculation`."""
+
+    # If the parameters of the second calculation are not passed, this is for the first step and we only return
+    # a dictionary with the volume, energy and derivative
+    if parameters_second is None:
+        V, E, dE = get_volume_energy_and_derivative(parameters_first)
+        return Dict(dict={'V': V, 'E': E, 'dE': dE})
+
+    # Otherwise, this is an iteration step and we return the difference between the steps
+    V, E, dE = get_volume_energy_and_derivative(parameters_first)
+    ddE = get_energy_second_derivative(parameters_first, parameters_second)
+    a, b, c = get_parabola_coefficients(V, E, dE, ddE)
+
+    return Dict(dict={'V': V, 'E': E, 'dE': dE, 'ddE': ddE, 'a': a, 'b': b, 'c': c})
+
+
+@calcfunction
+def bundle_step_data(step0, **kwargs):
+    steps = [step.get_dict() for step in kwargs.values()]
+    print(step0, type(step0))
+    print(steps, type(steps))
+    return Dict(dict={'step0': step0.get_dict(), 'steps': steps})
+
+
 class PressureConvergence(WorkChain):
-    """
-    Converge to minimum using Newton's algorithm on the first derivative of the energy (minus the pressure).
-    """
+    """Relax a structure using Newton's algorithm on the first derivative of the energy (minus the pressure)."""
 
     @classmethod
     def define(cls, spec):
         super(PressureConvergence, cls).define(spec)
-        spec.input('structure', valid_type=StructureData)
-        spec.input('volume_tolerance', valid_type=Float)
-        spec.input('code', valid_type=Str)
-        spec.input('pseudo_family', valid_type=Str)
+        spec.input('code', valid_type=Code,
+            help='Code setup to run `pw.x` to use for the calculations.')
+        spec.input('structure', valid_type=StructureData,
+            help='The structure to minimize.')
+        spec.input('pseudo_family', valid_type=Str,
+            help='Family of pseudopotentials to use for the calculations.')
+        spec.input('volume_tolerance', valid_type=Float,
+            help='Stop if the volume difference of two consecutive calculations is less than this threshold.')
+        spec.output('steps', valid_type=Dict,
+            help='The data of all the steps in the minimization process containing info about energy and volume')
+        spec.output('structure', valid_type=StructureData,
+            help='Final relaxed structure.')
         spec.outline(
             cls.setup,
             cls.put_step0_in_ctx,
@@ -105,100 +149,61 @@ class PressureConvergence(WorkChain):
         )
 
     def setup(self):
-        """
-        Launch the first calculation for the input structure,
-        and a second calculation for a shifted volume (increased by 4 angstrom^3)
-        Store the outputs of the two calcs in r0 and r1
-        """
-        print "Workchain node identifiers: {}".format(self.calc)
-
-        inputs0 = generate_scf_input_params(
-            self.inputs.structure, str(self.inputs.code), self.inputs.pseudo_family)
-
-        initial_volume = self.inputs.structure.get_cell_volume()
-        new_volume = initial_volume + 4.  # In ang^3
-
-        scaled_structure = get_structure(self.inputs.structure, new_volume)
-        inputs1 = generate_scf_input_params(
-            scaled_structure, str(self.inputs.code), self.inputs.pseudo_family)
-
+        """Launch the first calculation for the input structure, and a second calculation for a shifted volume."""
+        scaled_structure = get_structure(self.inputs.structure)
         self.ctx.last_structure = scaled_structure
 
-        # Run PW
-        future0 = submit(PwCalculation, **inputs0)
-        future1 = submit(PwCalculation, **inputs1)
+        inputs0 = generate_scf_input_params(self.inputs.structure, self.inputs.code, self.inputs.pseudo_family)
+        inputs1 = generate_scf_input_params(scaled_structure, self.inputs.code, self.inputs.pseudo_family)
 
-        # Wait to complete before next step
+        # Run two `PwCalculations`
+        future0 = self.submit(PwCalculation, **inputs0)
+        future1 = self.submit(PwCalculation, **inputs1)
+
+        # Wait for them to complete before going to the next step
         return ToContext(r0=future0, r1=future1)
 
     def put_step0_in_ctx(self):
-        """
-        Store the outputs of the very first step in a specific dictionary
-        """
-        V, E, dE = get_volume_energy_and_derivative(self.ctx.r0.get_outputs_dict()['output_parameters'])
+        """Store the outputs of the very first step in a specific dictionary."""
+        self.ctx.step0 = get_step_data(self.ctx.r0.outputs.output_parameters)
 
-        self.ctx.step0 = {'V': V, 'E': E, 'dE': dE}
-
-        # Prepare the list containing the steps
-        # step 1 will be stored here by move_next_step
+        # Prepare the list containing the steps: step 1 will be stored here by move_next_step
         self.ctx.steps = []
 
     def move_next_step(self):
-        """
-        Main routine that reads the two previous calculations r0 and r1,
-        uses the Newton's algorithm on the pressure (i.e., fits the results
-        with a parabola and sets the next point to calculate to the parabola
-        minimum).
-        r0 gets replaced with r1, r1 will get replaced by the results of the
-        new calculation.
-        """
-        r0_out = self.ctx.r0.get_outputs_dict()
-        r1_out = self.ctx.r1.get_outputs_dict()
-        ddE = get_second_derivative(r0_out['output_parameters'], r1_out['output_parameters'])
-        V, E, dE = get_volume_energy_and_derivative(r1_out['output_parameters'])
-        a, b, c = get_abc(V, E, dE, ddE)
+        """Main part of the algorithm.
 
-        new_step_data = {'V': V, 'E': E, 'dE': dE, 'ddE': ddE, 'a': a, 'b': b, 'c': c}
+        Compare the results of two consecutive calculations and use Newton's algorithm on the pressure by fitting the
+        results with a parabola and setting the next volume to calculate to the parabola minimum.
+
+        The oldest calculation gets replaced by the most recent and a new calculation is launched that will replace
+        the most recent.
+        """
+        # Computer the new Volume using Newton's algorithm and create the new corresponding structure by scaling it
+        new_step_data = get_step_data(self.ctx.r0.outputs.output_parameters, self.ctx.r1.outputs.output_parameters)
+        scaled_structure = get_structure(self.inputs.structure, new_step_data)
         self.ctx.steps.append(new_step_data)
 
-        # Minimum of a parabola
-        new_volume = -b / 2. / a
-
-        # remove older step
+        # Replace the older step with the latest and set the current structure
         self.ctx.r0 = self.ctx.r1
-        scaled_structure = get_structure(self.inputs.structure, new_volume)
         self.ctx.last_structure = scaled_structure
 
-        inputs = generate_scf_input_params(
-            scaled_structure, str(self.inputs.code), self.inputs.pseudo_family)
+        inputs = generate_scf_input_params(scaled_structure, self.inputs.code, self.inputs.pseudo_family)
+        future = self.submit(PwCalculation, **inputs)
 
-        # Run PW
-        future = submit(PwCalculation, **inputs)
-        # Replace r1
         return ToContext(r1=future)
 
     def not_converged(self):
-        """
-        Return True if the worflow is not converged yet (i.e., the volume changed significantly)
-        """
-        r0_out = self.ctx.r0.get_outputs_dict()
-        r1_out = self.ctx.r1.get_outputs_dict()
+        """Return True if the worflow is not converged yet (i.e. the volume changed significantly)."""
+        r0_out = self.ctx.r0.outputs.output_parameters
+        r1_out = self.ctx.r1.outputs.output_parameters
 
-        return abs(r1_out['output_parameters'].dict.volume -
-                   r0_out['output_parameters'].dict.volume) > self.inputs.volume_tolerance
+        return abs(r1_out.dict.volume - r0_out.dict.volume) > self.inputs.volume_tolerance
 
     def finish(self):
-        """
-        Output final quantities
-        """
-        self.out('steps', Dict(dict={'steps': self.ctx.steps, 'step0': self.ctx.step0}))
+        """Attach the result nodes as outputs."""
+        steps = {'step{}'.format(index + 1): step for index, step in enumerate(self.ctx.steps)}
+        bundled_steps = bundle_step_data(step0=self.ctx.step0, **steps)
+
+        self.out('steps', bundled_steps)
         self.out('structure', self.ctx.last_structure)
-
-
-if __name__ == '__main__':
-    structure = create_diamond_fcc(element=Str('Si'))
-    wf_results = run_eos(structure=structure)
-    print 'Initial structure:', structure
-    print 'Workflow results:'
-    print 'Final energies and fit parameters are stored in the Dict {}'.format(wf_results['steps'].pk)
-    print 'The optimized structure is stored in StructureData with pk {}'.format(wf_results['structure'].pk)

--- a/docs/pages/2019_MARVEL_Psik_MaX/scripts/simple_sync_workflow.py
+++ b/docs/pages/2019_MARVEL_Psik_MaX/scripts/simple_sync_workflow.py
@@ -1,39 +1,63 @@
+# -*- coding: utf-8 -*-
 from aiida.engine import run, Process, calcfunction, workfunction
-from aiida.orm import load_code
-from aiida.plugins import CalculationFactory, DataFactory
+from aiida.orm import load_code, Dict, Float, Str
+from aiida.plugins import CalculationFactory
 
 from create_rescale import create_diamond_fcc, rescale
 from common_wf import generate_scf_input_params
-
-Dict = DataFactory('dict')
-Float = DataFactory('float')
-Str = DataFactory('str')
 
 # Load the calculation class 'PwCalculation' using its entry point 'quantumespresso.pw'
 PwCalculation = CalculationFactory('quantumespresso.pw')
 
 
+@calcfunction
+def create_eos_dictionary(**kwargs):
+    """Create a single `Dict` node from the `Dict` output parameters of completed `PwCalculations`.
+
+    The dictionary will contain a list of tuples, where each tuple contains the volume, total energy and its units
+    of the results of a calculation.
+
+    :return: `Dict` node with the equation of state results
+    """
+    eos = [(result.dict.volume, result.dict.energy, result.dict.energy_units) for label, result in kwargs.items()]
+    return Dict(dict={'eos': eos})
+
+
 @workfunction
 def run_eos_wf(code, pseudo_family, element):
+    """Run an equation of state of a bulk crystal structure for the given element."""
+
     # This will print the pk of the work function
     print('Running run_eos_wf<{}>'.format(Process.current().pid))
 
     scale_factors = (0.96, 0.98, 1.0, 1.02, 1.04)
     labels = ['c1', 'c2', 'c3', 'c4', 'c5']
 
-    results = {}
+    calculations = {}
+
+    # Create an initial bulk crystal structure for the given element, using the calculation function defined earlier
     initial_structure = create_diamond_fcc(element)
 
+    # Loop over the label and scale_factor pairs
     for label, factor in zip(labels, scale_factors):
+
+        # Generated the scaled structure from the initial structure
         structure = rescale(initial_structure, Float(factor))
+
+        # Generate the inputs for the `PwCalculation`
         inputs = generate_scf_input_params(structure, code, pseudo_family)
 
+        # Launch a `PwCalculation` for each scaled structure
         print('Running a scf for {} with scale factor {}'.format(element, factor))
-        results[label] = run(PwCalculation, **inputs)
+        calculations[label] = run(PwCalculation, **inputs)
 
-    inputs = {label: result['output_parameters'] for label, result in results.items()}
-    eos = get_eos_data(**inputs)
+    # Bundle the individual results from each `PwCalculation` in a single dictionary node.
+    # Note: since we are 'creating' new data from existing data, we *have* to go through a `calcfunction`, otherwise
+    # the provenance would be lost!
+    inputs = {label: result['output_parameters'] for label, result in calculations.items()}
+    eos = create_eos_dictionary(**inputs)
 
+    # Finally, return the results of this work function
     result = {
         'initial_structure': initial_structure,
         'eos': eos
@@ -42,14 +66,7 @@ def run_eos_wf(code, pseudo_family, element):
     return result
 
 
-@calcfunction
-def get_eos_data(**kwargs):
-    eos = [(result.dict.volume, result.dict.energy, result.dict.energy_units) for label, result in kwargs.items()]
-    return Dict(dict={'eos': eos})
-
-
-def run_eos(code=load_code('pw-v6.1'), pseudo_family='SSSP_v1.1_efficiency_PBE', element='Si'):
-# def run_eos(code=load_code('qe-pw-6.2.1@localhost'), pseudo_family='GBRV_lda', element='Si'):
+def run_eos(code=load_code('qe-pw-6.2.1@localhost'), pseudo_family='GBRV_lda', element='Si'):
     return run_eos_wf(code, Str(pseudo_family), Str(element))
 
 

--- a/docs/pages/2019_MARVEL_Psik_MaX/sections/appendix_input_validation.rst
+++ b/docs/pages/2019_MARVEL_Psik_MaX/sections/appendix_input_validation.rst
@@ -3,7 +3,7 @@
 Calculation input validation
 ============================
 
-This appendix shows additional ways to debug errors with Quantum ESPRESSO, namely 
+This appendix shows additional ways to debug errors with Quantum ESPRESSO, namely
 how to take advantage of a powerful tool to validate the input to Quantum ESPRESSO
 and possibly suggest the correct name to misspelled keywords.
 
@@ -30,30 +30,30 @@ Let's check for example this input dictionary, where we inserted two mistakes:
 The two mistakes in the dictionary are the following:
 
 -  We wrote a wrong namelist name (``CTRL`` instead of ``CONTROL``).
--  We inserted the number of atoms explicitly: while that is indeed how the 
-   number of atoms is specified in Quantum ESPRESSO, in AiiDA this key is reserved by the system, 
+-  We inserted the number of atoms explicitly: while that is indeed how the
+   number of atoms is specified in Quantum ESPRESSO, in AiiDA this key is reserved by the system,
    since this information is already contained within the StructureData.
 
-After we correct the dictionary ``parameters_dict``, we could run the calculation directly. 
-Alternatively, we can use a tool of the the `aiida-quantumespresso` plugin, 
+After we correct the dictionary ``parameters_dict``, we could run the calculation directly.
+Alternatively, we can use a tool of the the `aiida-quantumespresso` plugin,
 the 'input helper', which checks the inputs before submitting the calculation.
 
-In your script, after you define ``parameters_dict``, 
-you can validate it with the following command (note that you need to pass also an input crystal structure, 
+In your script, after you define ``parameters_dict``,
+you can validate it with the following command (note that you need to pass also an input crystal structure,
 ``structure``, to allow the validator to perform all the needed checks):
 
 .. code:: python
 
     PwCalculation = CalculationFactory('quantumespresso.pw')
     validated_dict = PwCalculation.input_helper(parameters_dict, structure=structure)
-    parameters = ParameterData(dict=validated_dict)
+    parameters = Dict(dict=validated_dict)
 
 
 The ``input_helper``  method will check for the correctness of the input parameters.
-If misspelling or incorrect keys are detected, the method raises an exception, 
+If misspelling or incorrect keys are detected, the method raises an exception,
 which stops the script before submitting the calculation and thus allows for a more effective debugging.
 
-With this utility, you can also provide a list of keys, 
+With this utility, you can also provide a list of keys,
 without providing the namelists (useful if you don't remember where to put some variables in the input file).
 Hence, you can provide to ``input_helper`` a dictionary like this one:
 
@@ -69,8 +69,8 @@ Hence, you can provide to ``input_helper`` a dictionary like this one:
     }
 
     validated_dict = PwCalculation.input_helper(
-        parameters_dict, 
-        structure=structure, 
+        parameters_dict,
+        structure=structure,
         flat_mode=True
     )
 

--- a/docs/pages/2019_MARVEL_Psik_MaX/sections/include/snippets/workflows_rescale.py
+++ b/docs/pages/2019_MARVEL_Psik_MaX/sections/include/snippets/workflows_rescale.py
@@ -8,9 +8,7 @@ def rescale(structure, scale):
     """
     from aiida import orm
 
-    the_ase = structure.get_ase()
-    new_ase = the_ase.copy()
-    new_ase.set_cell(the_ase.get_cell() * float(scale), scale_atoms=True)
-    new_structure = orm.StructureData(ase=new_ase)
+    ase = structure.get_ase()
+    ase.set_cell(ase.get_cell() * float(scale), scale_atoms=True)
 
-    return new_structure
+    return orm.StructureData(ase=ase)


### PR DESCRIPTION
A big part of this was missed in the first run-through apparently. Many
of the advanced scripts, such as the equation of state work chain and the
pressure convergence work chain used the old API and were in general bad
examples of keeping provenance. I have significantly rewritten them,
such that they should now run with `aiida-core==1.0.0` and the
provenance should be kept a lot better by using calculation and work
functions were applicable.