### PR TITLE
Fix relative import paths in solution scripts

### DIFF
--- a/docs/pages/2019_MARVEL_Psik_MaX/scripts/equation_of_state.py
+++ b/docs/pages/2019_MARVEL_Psik_MaX/scripts/equation_of_state.py
@@ -7,8 +7,8 @@ from aiida.engine import WorkChain, ToContext, calcfunction
 from aiida.orm import Code, Dict, Float, Str, StructureData
 from aiida.plugins import CalculationFactory
 
-from .create_rescale import create_diamond_fcc, rescale
-from .common_wf import generate_scf_input_params
+from create_rescale import create_diamond_fcc, rescale
+from common_wf import generate_scf_input_params
 
 PwCalculation = CalculationFactory('quantumespresso.pw')
 scale_facs = (0.96, 0.98, 1.0, 1.02, 1.04)

--- a/docs/pages/2019_MARVEL_Psik_MaX/scripts/pressure_convergence.py
+++ b/docs/pages/2019_MARVEL_Psik_MaX/scripts/pressure_convergence.py
@@ -6,8 +6,8 @@ from aiida.engine import WorkChain, ToContext, while_, calcfunction, workfunctio
 from aiida.orm import Code, Float, Str, StructureData
 from aiida.plugins import CalculationFactory, DataFactory
 
-from .common_wf import generate_scf_input_params
-from .create_rescale import rescale
+from common_wf import generate_scf_input_params
+from create_rescale import rescale
 
 Dict = DataFactory('dict')
 KpointsData = DataFactory('array.kpoints')

--- a/docs/pages/2019_MARVEL_Psik_MaX/scripts/simple_sync_workflow.py
+++ b/docs/pages/2019_MARVEL_Psik_MaX/scripts/simple_sync_workflow.py
@@ -8,8 +8,8 @@ from aiida.engine import run, Process, calcfunction, workfunction
 from aiida.orm import load_code, Dict, Float, Str
 from aiida.plugins import CalculationFactory
 
-from .create_rescale import create_diamond_fcc, rescale
-from .common_wf import generate_scf_input_params
+from create_rescale import create_diamond_fcc, rescale
+from common_wf import generate_scf_input_params
 
 # Load the calculation class 'PwCalculation' using its entry point 'quantumespresso.pw'
 PwCalculation = CalculationFactory('quantumespresso.pw')


### PR DESCRIPTION
Fixes #78 

Starting the relative import with a period will cause calling
`verdi run` to fail