### PR TITLE
Fix various minor issues in May 2019 tutorial

### DIFF
--- a/docs/pages/2019_MARVEL_Psik_MaX/sections/calculations.rst
+++ b/docs/pages/2019_MARVEL_Psik_MaX/sections/calculations.rst
@@ -48,7 +48,7 @@ For ``local`` computers, this is just a "formality" (press enter to confirm the 
 
    For remote computers with ``ssh`` transport, use ``verdi computer configure ssh`` instead of ``verdi computer configure local``.
 
-Your ``localhost`` computer should now show up in 
+Your ``localhost`` computer should now show up in
 
 .. code:: bash
 
@@ -65,7 +65,7 @@ Code setup
 ----------
 
 Now that we have our localhost set up, let's configure the ``Code``, namely the ``pw.x`` executable.
-As with the computer, we have prepared a configuration file for you to :download:`download <include/configuration/computer.yml>`.
+As with the computer, we have prepared a configuration file for you to :download:`download <include/configuration/code.yml>`.
 This is its content:
 
 .. literalinclude:: include/configuration/code.yml
@@ -80,7 +80,7 @@ Once you have the configuration file in your local working environment, set up t
 .. warning::
 
     The configuration should work for the virtual machine that comes with this tutorial.
-    If you are following this tutorial in a different environment, you will need to install Quantum ESPRESSO and adapt the configuration to your needs, 
+    If you are following this tutorial in a different environment, you will need to install Quantum ESPRESSO and adapt the configuration to your needs,
     as explained in :ref:`this appendix<appendix_computer_code_setup>`.
 
 Similar to the computers, you can list all the configured codes with:
@@ -376,8 +376,8 @@ current directory. In your second terminal:
    The files created by a dry run are only intended for  inspection
    and cannot be used to correct the inputs of your calculation.
 
-Storing and submitting the calculation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Submitting the calculation
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Up to now we've just been playing around and our calculation has been kept
 in memory and not in the database.

--- a/docs/pages/2019_MARVEL_Psik_MaX/sections/include/configuration/code.yml
+++ b/docs/pages/2019_MARVEL_Psik_MaX/sections/include/configuration/code.yml
@@ -6,3 +6,4 @@ on_computer: true
 remote_abs_path: "/home/max/codes/q-e-90a2aa88298f5005b8ab8f5fcc354c5870481d68/bin/pw.x"
 computer: "localhost"
 prepend_text: "ulimit -s unlimited"
+append_text: " "

--- a/docs/pages/2019_MARVEL_Psik_MaX/sections/include/configuration/computer.yml
+++ b/docs/pages/2019_MARVEL_Psik_MaX/sections/include/configuration/computer.yml
@@ -1,4 +1,5 @@
 ---
+description: "localhost"
 label: "localhost"
 hostname: "localhost"
 transport: local
@@ -6,3 +7,6 @@ scheduler: "direct"
 work_dir: "/home/max/.aiida_run"
 mpirun_command: "mpirun -np {tot_num_mpiprocs}"
 mpiprocs_per_machine: "2"
+shebang: "#!/bin/bash"
+prepend_text: " "
+append_text: " "

--- a/docs/pages/2019_MARVEL_Psik_MaX/sections/verdi_cmdline.rst
+++ b/docs/pages/2019_MARVEL_Psik_MaX/sections/verdi_cmdline.rst
@@ -1,7 +1,7 @@
 Verdi command line
 ==================
 
-This part of the tutorial will familiarize you with the ``verdi`` command-line interface (CLI), 
+This part of the tutorial will familiarize you with the ``verdi`` command-line interface (CLI),
 which lets you manage your AiiDA installation, inspect the contents of your database,  control running calculations and more.
 
  * The ``verdi`` command supports **tab-completion**:
@@ -52,7 +52,7 @@ To see this profile, and any others that may have been configured, run:
     * generic
       quicksetup
 
-Each line, ``generic`` and ``quicksetup`` in this example, corresponds to a profile. 
+Each line, ``generic`` and ``quicksetup`` in this example, corresponds to a profile.
 The one marked with an asterisk is the "default" profile, meaning that any ``verdi`` command that you execute will be applied to that profile.
 
 .. note::
@@ -178,7 +178,7 @@ Now you can connect the provenance browser to your local REST API:
 
 -  Open the |provenance_browser| on your laptop
 -  In the form, paste the (local) URL ``http://127.0.0.1:5000/api/v3``
-   of our REST API 
+   of our REST API
 -  Click "GO!"
 
 .. |provenance_browser| raw:: html
@@ -229,8 +229,8 @@ which should be empty:
 
 .. code:: bash
 
-    PK    Created    State    Process label    Process status
-    ----  ---------  -------  ---------------  ----------------
+    PK    Created    Process label   Process State    Process status
+    ----  ---------  --------------  ---------------  ----------------
 
     Total results: 0
 
@@ -246,14 +246,14 @@ This command will list all the processes that have a process state ``Finished`` 
 
 .. code:: bash
 
-    PK    Created    State           Process label    Process status
+    PK    Created    Process label   Process State    Process status
     ----  ---------  --------------  ---------------  ----------------
-    1178  1653D ago  ⏹ Finished [0]  PwCalculaton
-    1953  1653D ago  ⏹ Finished [0]  PwCalculaton
-    1734  1653D ago  ⏹ Finished [0]  PwCalculaton
-     336  1653D ago  ⏹ Finished [0]  PwCalculaton
-    1056  1653D ago  ⏹ Finished [0]  PwCalculaton
-    1369  1653D ago  ⏹ Finished [0]  PwCalculaton
+    1178  1653D ago  PwCalculaton    ⏹ Finished [0]
+    1953  1653D ago  PwCalculaton    ⏹ Finished [0]
+    1734  1653D ago  PwCalculaton    ⏹ Finished [0]
+     336  1653D ago  PwCalculaton    ⏹ Finished [0]
+    1056  1653D ago  PwCalculaton    ⏹ Finished [0]
+    1369  1653D ago  PwCalculaton    ⏹ Finished [0]
 
     Total results: 6
 


### PR DESCRIPTION
* Link to configuration file for code pointed to wrong file
* Change header of: 'Storing and submitting the calculation'
* Config computer: add shebang, description, append and prepend text
* Config code: add append
* Adapt column order of `verdi process list`

Note that the append and prepend text values in the configuration files
have been set to a single space, in case no specific value needs to be
set. Leaving it unset or to an empty string, will cause the editor to be
prompted regardless.