### PR TITLE
Update download link export archive to new version 0.3

### DIFF
--- a/docs/pages/2019_MARVEL_Psik_MaX/sections/verdi_cmdline.rst
+++ b/docs/pages/2019_MARVEL_Psik_MaX/sections/verdi_cmdline.rst
@@ -82,7 +82,7 @@ Let's import one from the web:
 
 .. code:: bash
 
-    verdi import https://object.cscs.ch/v1/AUTH_b1d80408b3d340db9f03d373bbde5c1e/marvel-vms/tutorials/aiida_tutorial_2019_05_perovskites_v0.2.aiida
+    verdi import https://object.cscs.ch/v1/AUTH_b1d80408b3d340db9f03d373bbde5c1e/marvel-vms/tutorials/aiida_tutorial_2019_05_perovskites_v0.3.aiida
 
 Contrary to most databases, AiiDA databases contain not only *results* of calculations but also their inputs and information on how a particular result was obtained.
 This information, the *data provenance*, is stored in the form of a *directed acyclic graph* (DAG).


### PR DESCRIPTION
Archive v0.2 contained `PwCalculaton` instead of `PwCalculation` for the
process label. This minor cosmetic fix was performed and exported in a
new archive v0.3