### PR TITLE
transifex integrated with travis CI into repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
     - BUILD: docs
       TARGET: latexpdf
     - BUILD: pre-commit
+    - BUILD: transifex-upload
 
 install:
   - pip install --upgrade pip
@@ -38,6 +39,13 @@ script:
      # -C docs: switch to docs/ directory
       make -C docs pre-docs
       make -C docs $TARGET
+    elif [ "$BUILD" == "transifex-upload" ]; then
+      TRANSIFEX_PROJECT_NAME="aiida-tutorials"
+      sphinx-build -b gettext -D gettext_compact=0 docs locale
+      tx init --no-interactive
+      sphinx-intl update-txconfig-resources --pot-dir locale --transifex-project-name ${TRANSIFEX_PROJECT_NAME}
+      sudo echo $'[https://www.transifex.com]\nhostname = https://www.transifex.com\nusername = '"$TRANSIFEX_USER"$'\npassword = '"$TRANSIFEX_PASSWORD"$'\n' > ~/.transifexrc
+      tx push -s
     else
       pre-commit install
       pre-commit run --all-files || ( git status --short; git diff ; exit 1 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ ipykernel>=4.10,<5.0
 pre-commit>=1.16,<2
 prospector>=1.1,<1.2
 yapf==0.27.0
+# transifex
+sphinx-intl==2.0.0
+transifex-client==0.13.6


### PR DESCRIPTION
@ltalirz Same way as aiida-core's documentation localization.
The repository is held at https://github.com/unkcpz/aiida-tutorial-zh_CN now.
The traivis CI build successfully, https://travis-ci.org/unkcpz/aiida-tutorials/jobs/558791220 .

You can find output of readthedocs result here https://aiida-tutorial-zh-cn.readthedocs.io/zh_CN/latest/ .