### PR TITLE
Various small updates for SINTEF based on Xiamen tutorial

### DIFF
--- a/docs/pages/2019_SINTEF/notebooks/bandstructure.ipynb
+++ b/docs/pages/2019_SINTEF/notebooks/bandstructure.ipynb
@@ -58,7 +58,7 @@
     "# Loading the COD importer so we can directly import structure from COD id's\n",
     "importer = CodDbImporter()\n",
     "# Make sure here to define the correct codename that corresponds to the pw.x code installed on your machine of choice\n",
-    "codename = 'qe-6.3-pw@localhost'\n",
+    "codename = 'qe-6.4.1-pw@localhost'\n",
     "code = Code.get_from_string(codename)"
    ]
   },

--- a/docs/pages/2019_SINTEF/scripts/simple_sync_workflow.py
+++ b/docs/pages/2019_SINTEF/scripts/simple_sync_workflow.py
@@ -73,7 +73,7 @@ def run_eos_wf(code, pseudo_family, element):
     return result
 
 
-def run_eos(code=load_code('qe-6.3-pw@localhost'),
+def run_eos(code=load_code('qe-6.4.1-pw@localhost'),
             pseudo_family='SSSP',
             element='Si'):
     """Helper function to run EOS WorkChain."""

--- a/docs/pages/2019_SINTEF/sections/calculations.rst
+++ b/docs/pages/2019_SINTEF/sections/calculations.rst
@@ -89,12 +89,12 @@ Similar to the computers, you can list all the configured codes with:
 
     verdi code list
 
-Verify that it now contains a code named ``qe-6.3-pw`` that we just configured.
+Verify that it now contains a code named ``qe-6.4.1-pw`` that we just configured.
 You can always check the configuration details of an existing code using:
 
 .. code:: bash
 
-    verdi code show qe-6.3-pw
+    verdi code show qe-6.4.1-pw
 
 .. note::
 
@@ -172,7 +172,7 @@ There should be a number of them. Here, we're interested in the "PWscf" executab
     verdi code list -P quantumespresso.pw
 
 Pick the correct codename, that might look like, e.g.
-``qe-6.3-pw@localhost`` and load it in the verdi shell.
+``qe-6.4.1-pw@localhost`` and load it in the verdi shell.
 
 .. code:: python
 
@@ -279,7 +279,7 @@ we provide) and link it to the calculation using the command:
     from aiida.orm.nodes.data.upf import get_pseudos_from_structure
     builder.pseudos = get_pseudos_from_structure(structure, '<PSEUDO_FAMILY_NAME>')
 
-Print the content of the `pseudos` namespace (`print(builder.pseudos)`) to see what the helper function created.
+Print the content of the `pseudos` namespace, e.g. ``print(builder.pseudos)`` to see what the helper function created.
 
 Preparing and debugging input parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/pages/2019_SINTEF/sections/first_taste.rst
+++ b/docs/pages/2019_SINTEF/sections/first_taste.rst
@@ -158,7 +158,6 @@ AiiDA should now have access to your neighbor's computer. Let's quickly test thi
 Finally, let AiiDA know about the **code** we are going to use.
 We've again prepared a template that looks as follows:
 
-.. Add template for code
 .. literalinclude:: include/configuration/qe.yml
 
 Download the :download:`qe.yml <include/configuration/qe.yml>` code template and run:
@@ -187,8 +186,61 @@ From calculations to workflows
 ------------------------------
 
 AiiDA can help you run individual calculations but it is really designed to help you run workflows that involve several calculations, while automatically keeping track of the provenance for full reproducibility.
+As the final step, let's actually run a workflow.
 
-As the final step, we are going to launch the ``PwBandStructure`` workflow of the ``aiida-quantumespresso`` plugin.
+.. code:: bash
+
+  verdi plugin list aiida.workflows
+
+This should show a list of workflows that are currently installed:
+
+.. code:: bash
+
+  Registered entry points for aiida.workflows:
+  * quantumespresso.matdyn.base
+  * quantumespresso.ph.base
+  * quantumespresso.pw.band_structure
+  * quantumespresso.pw.bands
+  * quantumespresso.pw.base
+  * quantumespresso.pw.relax
+  * quantumespresso.q2r.base
+  * zeopp.blockpockets
+
+  Info: Pass the entry point as an argument to display detailed information
+
+Let's try to run the ``quantumespresso.pw.band_structure`` workflow.
+This is a workflow from the ``aiida-quantumespresso`` plugin that, for a given structure, will compute the electronic band structure.
+Let's see what inputs it takes and what outputs it will produce:
+
+.. code:: bash
+
+  verdi plugin list aiida.workflows quantumespresso.pw.band_structure
+
+which should display:
+
+.. code:: bash
+
+  Inputs
+                   code:  required  Code           The `pw.x` code to use for the `PwCalculations`.
+              structure:  required  StructureData  The input structure.
+               metadata:  optional
+                options:  optional  Dict           Optional `options` to use for the `PwCalculations`.
+               protocol:  optional  Dict           The protocol to use for the workchain.
+  Outputs
+        band_parameters:  required  Dict
+         band_structure:  required  BandsData
+    primitive_structure:  required  StructureData
+         scf_parameters:  required  Dict
+    seekpath_parameters:  required  Dict
+  Exit codes
+                      1:  The process has failed with an unspecified error.
+                      2:  The process failed with legacy failure mode.
+                     10:  The process returned an invalid output.
+                     11:  The process did not register a required output.
+                    201:  Input `structuredata` contains an unsupported kind.
+                    401:  The `pwbandsworkchain` sub process failed.
+
+The following snippet shows how you can actually run this workflow.
 
 .. literalinclude:: include/snippets/demo_bands.py
 

--- a/docs/pages/2019_SINTEF/sections/verdi_cmdline.rst
+++ b/docs/pages/2019_SINTEF/sections/verdi_cmdline.rst
@@ -112,7 +112,7 @@ Have a look to the figure and its caption before moving on.
    The node with linkname 'retrieved' contains the raw output files stored in the AiiDA repository; all other nodes are added by the parser.
    Additional nodes (symbolized in gray) can be added by the parser (e.g. an output ``StructureData`` if you performed a relaxation calculation, a ``TrajectoryData`` for molecular dynamics etc.).
 
-:numref:`2019_sintef_fig_graph_input_only` was drawn by hand but you can generate a similar graph automatically by passing the **identifier** of a calculation node to ``verdi graph generate <IDENTIFIER>``.
+:numref:`2019_sintef_fig_graph_input_only` was drawn by hand but you can generate a similar graph automatically by passing the **identifier** of a calculation node to ``verdi node graph generate <IDENTIFIER>``.
 Identifiers in AiiDA come in three forms:
 
  * "Primary Key" (PK): An integer, e.g. ``723``, that identifies your entity within your database (automatically assigned)
@@ -132,17 +132,9 @@ With that in mind, let's generate a graph for the calculation node with UUID ``c
 
 .. code:: bash
 
-    verdi graph generate <IDENTIFIER>
+    verdi node graph generate <IDENTIFIER>
 
-This command will create the file ``<PK>.dot`` that can be rendered by means of the utility ``dot`` as follows:
-
-.. code:: bash
-
-    dot -Tpdf -o <PK>.pdf <PK>.dot
-
-which will create a pdf file ``<PK>.pdf``.
-
-
+This command will create the file ``<PK>.dot.pdf`` that can be viewed with any PDF document viewer.
 You can open this file on the Amazon machine by using ``evince`` or, if the ssh connection is too slow, copy it via ``scp`` to your local machine.
 To do so, if you are using Linux/Mac OS X, you can type in your *local* machine:
 
@@ -497,16 +489,16 @@ Node with UUID prefix ``ce81c420`` should have no comments, but you can add a ve
 
 .. code:: bash
 
-    verdi comment add "vc-relax of a BaTiO3 done with QE pw.x" -N <IDENTIFIER>
+    verdi node comment add "vc-relax of a BaTiO3 done with QE pw.x" -N <IDENTIFIER>
 
 Now, if you ask for a list of all comments associated to that calculation by typing:
 
 .. code:: bash
 
-    verdi comment show <IDENTIFIER>
+    verdi node comment show <IDENTIFIER>
 
 the comment that you just added will appear together with some useful information such as its creator and creation date.
-We let you play with the other options of ``verdi comment`` command to learn how to update or remove comments.
+We let you play with the other options of ``verdi node comment`` command to learn how to update or remove comments.
 
 AiiDA groups of calculations
 ----------------------------

--- a/docs/pages/2019_SINTEF/sections/workflows.rst
+++ b/docs/pages/2019_SINTEF/sections/workflows.rst
@@ -298,7 +298,7 @@ For simplicity, we have included few lines at the end of the script that invoke 
 
 .. code:: python
 
-    def run_eos(code=load_code('qe-6.3-pw@localhost'), pseudo_family='SSSP', element='Si'):
+    def run_eos(code=load_code('qe-6.4.1-pw@localhost'), pseudo_family='SSSP', element='Si'):
         return run_eos_wf(code, Str(pseudo_family), Str(element))
 
     if __name__ == '__main__':
@@ -475,7 +475,7 @@ For example, you can execute:
 .. code:: python
 
     from aiida.engine import run
-    run(EquationOfState, element=Str('Si'), code=load_code('qe-6.3-pw@localhost'), pseudo_family=Str('SSSP'))
+    run(EquationOfState, element=Str('Si'), code=load_code('qe-6.4.1-pw@localhost'), pseudo_family=Str('SSSP'))
 
 While the workflow is running, you can check (in a different terminal) what is happening to the calculations using ``verdi process list``.
 You will see that after a few seconds the calculations are all submitted to the scheduler and can potentially run at the same time.


### PR DESCRIPTION
The SINTEF tutorial text was copied from Xiamen which was copied from
the Lausann May 2019 tutorial. The latter used `aiida-core==1.0.0b3`
whereas the current uses `aiida-core==1.0.0b6`. The Xiamen tutorial did
not update the text accordingly since only the new introductory section
`A first taste` was used.

Following changes were made:

  - `verdi graph generate` -> `verdi node graph generate`
  - `verdi comment` -> `verdi node comment`
  - Code label `qe-6.3-pw` renamed to `qe-6.4.1-pw`

These snippets were added:

  - `Demo: a first taste`: added small block to explain the use of
    `verdi plugin list aiida.workflows` to see the required inputs for
    the band structure work chain before they run it.