### PR TITLE
SINTEF September 2019: fixing the getting started instructions

### DIFF
--- a/docs/pages/2019_SINTEF/sections/setup.rst
+++ b/docs/pages/2019_SINTEF/sections/setup.rst
@@ -34,14 +34,14 @@ Add the following block your
      Host aiidatutorial
          Hostname IP_ADDRESS
          User max
+         IdentityFile ~/.ssh/aiida_tutorial_NUM
          ForwardX11 yes
          ForwardX11Trusted yes
          LocalForward 8888 localhost:8888
          LocalForward 5000 localhost:5000
          ServerAliveInterval 120
 
-replacing the IP address (``IP_ADDRESS``) and the ``NUM`` by
-the one you received.
+replacing the IP address (``IP_ADDRESS``) and the ``NUM`` by the one you received.
 
 Afterwards you can connect to the server using this simple command:
 
@@ -59,6 +59,7 @@ Afterwards you can connect to the server using this simple command:
       ssh \
             -L 8888:localhost:8888 \
             -L 5000:localhost:5000 \
+            -I ~/.ssh/aiida_tutorial_NUM
             -o ServerAliveInterval=120 \
             -X -C \
             max@IP_ADDRESS
@@ -75,13 +76,27 @@ If you're running Windows 10, you may want to consider `installing the Windows S
 
 -  Install the `PuTTY SSH client <https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html>`_.
 
+-  Run PuTTYGen
+
+   -  Load the ``aiida_tutorial_NN`` private key (button
+      "Load"). You may need to choose to show "All files (*.*)",
+      and select the file without any extension (Type: File).
+   -  In the same window, click on "Save private Key", and save the key
+      with the name ``aiida_tutorial_NN.ppk`` (don't specify a password).
+
+-  Run Pageant
+
+   -  It will add a new icon near the clock, in the bottom right of your screen.
+   -  Right click on this Pageant icon, and click on “View Keys”.
+   -  Click on "Add key" and select the ``aiida_tutorial_NN.ppk`` you saved a few steps above.
+
 -  Run PuTTY
 
    -  Put the given IP address as hostname, type ``aiidatutorial`` in "Saved Sessions"
-      and click "Save".
-   -  Go to Connection > Data and put ``max`` as autologin username.
+      and click "Save". 
+   -  Go to Connection > Data and put ``max`` as autologin username. 
    -  Go to Connection > SSH > Tunnels, type ``8888`` in the
-      "Source Port" box, type ``localhost:8888`` in "Destination" and click "Add".
+      "Source Port" box, type ``localhost:8888`` in "Destination" and click "Add". 
    -  Repeat the previous step for port ``5000`` instead of ``8888``.
    -  Go back to the "Session" screen, select "aiidatutorial" and click "Save"
    -  Finally, click "Open" (and click "Yes" on the putty security alert


### PR DESCRIPTION
 * For Linux/MacOS the `IdentityFile` directive was using
 * For Windows the generating and registering the keys with PuTTygen and
   Pageant was missing