### PR TITLE
Re-enabling documentation in notebooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
   matrix:
     - BUILD: docs
       TARGET: html
-      SPHINXOPTS: -W
+      SPHINXOPTS: -nW
     - BUILD: docs
       TARGET: latexpdf
     - BUILD: pre-commit
@@ -35,8 +35,6 @@ install:
 script: 
   - >
     if [ "$BUILD" == "docs" ]; then 
-     # -C docs: switch to docs/ directory
-      make -C docs pre-docs
       make -C docs $TARGET
     else
       pre-commit install

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+import os
+import subprocess
+
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -355,9 +358,9 @@ intersphinx_mapping = {
 
 # Compile all things needed before building the docs
 # For instance, convert the notebook templates to actual tutorial and solution versions
-import os
-import subprocess
-print(subprocess.check_output(
-        ['make', '-C', os.path.dirname(os.path.realpath(__file__)), 'pre-docs'],
-        universal_newlines=True)
-)
+print(
+    subprocess.check_output([
+        'make', '-C',
+        os.path.dirname(os.path.realpath(__file__)), 'pre-docs'
+    ],
+                            universal_newlines=True))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -352,3 +352,12 @@ nbsphinx_execute = 'never'
 intersphinx_mapping = {
     'aiida': ('http://aiida-core.readthedocs.org/en/latest/', None)
 }
+
+# Compile all things needed before building the docs
+# For instance, convert the notebook templates to actual tutorial and solution versions
+import os
+import subprocess
+print(subprocess.check_output(
+        ['make', '-C', os.path.dirname(os.path.realpath(__file__)), 'pre-docs'],
+        universal_newlines=True)
+)


### PR DESCRIPTION
Due to some changes in the code, and the removal of version of the jupyer notebook files that were pushed but should have been created automatically instead by the `pre-docs` make build (in particular, creating `tutorial` and `solution` versions from notebook templates), the docs didn't include the rendered version of the notebooks anymore (in particular the QueryBuilder sections).

Now, I invoke `make pre-docs` in the correct folder within the `conf.py` file, so that sphinx will first call the makefile before attempting any doc compilation.

This PR fixes #205 
I also make the travis tests a bit stricter, so that next time this error should be caught instead.