### PR TITLE
Add sphinx-copybutton extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,9 +39,14 @@ extensions = [
     'nbsphinx',
     'sphinx.ext.extlinks',
     'sphinx.ext.mathjax',
+    'sphinx_copybutton',
 ]
 ipython_mplbackend = ""
 imgmath_image_format = 'svg'
+
+copybutton_selector = 'div:not(.no-copy)>div.highlight pre'
+copybutton_prompt_text = '>>> |\\\\$ |In \\\\[\\\\d\\\\]: |\\\\s+\\.\\.\\.: '
+copybutton_prompt_is_regexp = True
 
 todo_include_todos = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Sphinx>=2.0,<3.0
 sphinx-rtd-theme>=0.4.3,<0.5
+sphinx-copybutton~=0.2.12
 ipython>=4.0,<6.0
 recommonmark>=0.5.0
 nbsphinx>=0.4.2,<0.5


### PR DESCRIPTION
Add the `sphinx-copybutton` extension for the 2020 virtual AiiDA tutorial. 

I think this is a very useful feature to have for the tutorial, but it will require changes to all the prompts to make sure the copy button works as intended. Also, when we merge this branch into `master`, the copy button will not be very useful for previous tutorials that do not conform to the prompt standards, unless we change all the prompts.

What do you think, @chrisjsewell?