### PR TITLE
Add section on exploring proveneance

### DIFF
--- a/docs/pages/2020_Intro_Week/notebooks/querybuilder-template.md
+++ b/docs/pages/2020_Intro_Week/notebooks/querybuilder-template.md
@@ -542,9 +542,50 @@ qb.all()
 #TUT_SOLUTION_END
 ```
 
-```{seealso}
-For more exercises on relationships and attributes/extras, have a look at the appendix section on queries.
+## Generating a provenance graph
+
++++
+
+Previously we have used `verdi graph generate` on the command-line, to generate a graph of the data provenance.
+To do this, AiiDA actually uses some of the queries which you have learn't about above.
+We can also visualise sections of the provenance in a more customisable way, using the `Graph` class.
+
+For example, lets query for a calculation, then use methods of the `Graph` class to visualise the inputs and outputs of this calculation:
+
+```{code-cell} ipython3
+qb = QueryBuilder()
+qb.append(PwCalculation)
+node, = qb.first()
+
+from aiida.tools.visualization import Graph
+graph = Graph(graph_attr={"rankdir": "LR"})
+
+graph.add_incoming(node.uuid, annotate_links="both")
+graph.add_outgoing(node.uuid, annotate_links="both")
+graph.graphviz
 ```
+
+The `Graph` class also has methods for recurcing up or down the provenenance tree.
+In this example, lets query for a pseudopotential, and visualise which processes it is used in:
+
+```{code-cell} ipython3
+qb = QueryBuilder()
+qb.append(UpfData, filters={'attributes.element': {'==': 'Si'}})
+node, = qb.first()
+
+graph = Graph(graph_attr={"rankdir": "LR"})
+
+graph.recurse_descendants(
+    node.uuid,
+    annotate_links="both",
+    depth=1
+)
+graph.graphviz
+```
+
+For further information on using `Graph` to generate provenanace graphs, please see [this section](https://aiida.readthedocs.io/projects/aiida-core/en/latest/howto/visualising_graphs/visualising_graphs.html) in the documentation.
+
+You can also explore the provenance in other ways. If you have time, please work through [this appendix](https://aiida-tutorials.readthedocs.io/en/latest/pages/2020_Intro_Week/appendices/exploring_provenance.html) on exploring provenance.
 
 +++
 

--- a/docs/pages/2020_Intro_Week/notebooks/querybuilder-template.md
+++ b/docs/pages/2020_Intro_Week/notebooks/querybuilder-template.md
@@ -547,10 +547,10 @@ qb.all()
 +++
 
 Previously we have used `verdi graph generate` on the command-line, to generate a graph of the data provenance.
-To do this, AiiDA actually uses some of the queries which you have learn't about above.
+To do this, AiiDA actually uses some of the queries which you have learned about above.
 We can also visualise sections of the provenance in a more customisable way, using the `Graph` class.
 
-For example, lets query for a calculation, then use methods of the `Graph` class to visualise the inputs and outputs of this calculation:
+For example, let's query for a calculation, then use methods of the `Graph` class to visualise the inputs and outputs of this calculation:
 
 ```{code-cell} ipython3
 qb = QueryBuilder()
@@ -565,8 +565,8 @@ graph.add_outgoing(node.uuid, annotate_links="both")
 graph.graphviz
 ```
 
-The `Graph` class also has methods for recurcing up or down the provenenance tree.
-In this example, lets query for a pseudopotential, and visualise which processes it is used in:
+The `Graph` class also has methods for recursing up or down the provenance tree.
+In this example, let's query for a pseudopotential, and visualise which processes it is used in:
 
 ```{code-cell} ipython3
 qb = QueryBuilder()
@@ -583,7 +583,7 @@ graph.recurse_descendants(
 graph.graphviz
 ```
 
-For further information on using `Graph` to generate provenanace graphs, please see [this section](https://aiida.readthedocs.io/projects/aiida-core/en/latest/howto/visualising_graphs/visualising_graphs.html) in the documentation.
+For further information on using `Graph` to generate provenance graphs, please see [this section](https://aiida.readthedocs.io/projects/aiida-core/en/latest/howto/visualising_graphs/visualising_graphs.html) in the documentation.
 
 You can also explore the provenance in other ways. If you have time, please work through [this appendix](https://aiida-tutorials.readthedocs.io/en/latest/pages/2020_Intro_Week/appendices/exploring_provenance.html) on exploring provenance.
 


### PR DESCRIPTION
Small addition to quickly merge 😬 
In the current notebook, it references an appendix section that doesn't exist. Also there was no direct link to the `exploring_provenance` appendix.
So I add that below, plus a small section on the `Graph` API.

Obviously I have tested these outputs in the "solution" notebook. This is what it looks like:

![image](https://user-images.githubusercontent.com/2997570/86876353-723a8f80-c0dc-11ea-9ddd-a0829bd1d5a5.png)
![image](https://user-images.githubusercontent.com/2997570/86876361-7bc3f780-c0dc-11ea-89c7-9fd4be80985c.png)
