### PR TITLE
Final small fixes for advanced workflows section

### DIFF
--- a/docs/pages/2020_Intro_Week/sections/workflows_adv.rst
+++ b/docs/pages/2020_Intro_Week/sections/workflows_adv.rst
@@ -294,6 +294,14 @@ When submitting or running the work chain using namespaced inputs (``add`` in th
     }
     submit(ArithmeticAddBaseWorkChain, **inputs)
 
+.. important::
+
+    After making the changes to the ``ArithmeticAddBaseWorkChain``, don't forget to restart the daemon with:
+
+    .. code-block:: bash
+
+        $ verdi daemon restart --reset
+
 Error handling
 ==============
 So far you have seen how easy it is to get a work chain up and running that will run a subprocess using the ``BaseRestartWorkChain``.

--- a/docs/pages/2020_Intro_Week/sections/workflows_adv.rst
+++ b/docs/pages/2020_Intro_Week/sections/workflows_adv.rst
@@ -296,7 +296,7 @@ When submitting or running the work chain using namespaced inputs (``add`` in th
 
 .. important::
 
-    After making the changes to the ``ArithmeticAddBaseWorkChain``, don't forget to restart the daemon with:
+    Every time you make changes to the ``ArithmeticAddBaseWorkChain``, don't forget to restart the daemon with:
 
     .. code-block:: bash
 
@@ -312,7 +312,7 @@ Let's launch the work chain with inputs that will cause the calculation to fail,
 
 .. code-block:: python
 
-    submit(ArithmeticAddBaseWorkChain, x=Int(3), y=Int(-4), code=load_code('add@tutor'))
+    submit(ArithmeticAddBaseWorkChain, add={'x': Int(3), 'y': Int(-4), 'code': load_code('add@tutor')})
 
 This time we will see that the work chain takes quite a different path:
 

--- a/docs/pages/2020_Intro_Week/sections/workflows_adv.rst
+++ b/docs/pages/2020_Intro_Week/sections/workflows_adv.rst
@@ -6,19 +6,10 @@ Workflows: Advanced
 
 In this hands-on, we'll be looking at some more advanced concepts related to workflows.
 
-.. note::
+.. important::
 
-    If you have not already been through :ref:`2020_virtual_intro:workflow_basic`, you should setup the proper ``Code``:
-
-    To set up the ``Code`` the work chain uses to add two numbers together:
-
-    .. code-block:: console
-
-        $ verdi code setup -L add --on-computer --computer=localhost -P arithmetic.add --remote-abs-path=/bin/bash -n
-
-    This command sets up a code with *label* ``add`` on the *computer* ``localhost``, using the *plugin* ``arithmetic.add``.
-
-    To learn more about setting up a computer see :ref:`2020_virtual_intro:running:computer`.
+    Just as in the :ref:`2020_virtual_intro:workflow_basic` section, we will be using the computers and codes set up in the first two hands-on sessions.
+    Make sure you have the profile you :ref:`set up at the start of the tutorial<2020_virtual_intro:setup_profile>` set as the default.
 
 Exit Codes
 **********
@@ -217,7 +208,7 @@ We can now launch it like any other work chain and the ``BaseRestartWorkChain`` 
 
 .. code-block:: python
 
-    submit(ArithmeticAddBaseWorkChain, x=Int(3), y=Int(4), code=load_code('add@localhost'))
+    submit(ArithmeticAddBaseWorkChain, x=Int(3), y=Int(4), code=load_code('add@tutor'))
 
 Once the work chain finished, we can inspect what has happened with, for example, ``verdi process status``:
 
@@ -298,7 +289,7 @@ When submitting or running the work chain using namespaced inputs (``add`` in th
         'add': {
             'x': Int(3),
             'y': Int(4),
-            'code': load_code('add@localhost')
+            'code': load_code('add@tutor')
         }
     }
     submit(ArithmeticAddBaseWorkChain, **inputs)
@@ -313,7 +304,7 @@ Let's launch the work chain with inputs that will cause the calculation to fail,
 
 .. code-block:: python
 
-    submit(ArithmeticAddBaseWorkChain, x=Int(3), y=Int(-4), code=load_code('add@localhost'))
+    submit(ArithmeticAddBaseWorkChain, x=Int(3), y=Int(-4), code=load_code('add@tutor'))
 
 This time we will see that the work chain takes quite a different path:
 


### PR DESCRIPTION
This PR does the following:
* Turn the starting message into a quick note that they need to use the right profile as the default instead of installing a new code on the `localhost` computer.

* Fix the code snippets that use the `add@localhost` computer by putting in `add@tutor` instead. As this is the one that is set up in the basics section.

* Add a note on restarting the daemon *every* time they make a change to the `ArithmeticAddBaseWorkChain`.

* Change the submit command shown after the "Expose inputs and outputs" section so it also uses the `add` namespace.

Re `add@tutor`: I think it's better to simply reuse this *bad* tutor computer instead of confusing them with the installation of the add code on a different computer. Of course, it would have been better to simply set up the `localhost` computer at the start and use this one for both the `add` and `qe` codes. I will make up for my failure in this regard with *ample* amounts of Belgian beer upon my arrival in Lausanne.