### PR TITLE
Plugin package and example

### DIFF
--- a/docs/sections/creating_plugins/cutter.md
+++ b/docs/sections/creating_plugins/cutter.md
@@ -12,5 +12,5 @@ This is is an open-ended task aimed at getting you through initial hurdles more 
 ## Useful resources
 
 * [Guidelines on plugin design](<https://aiida.readthedocs.io/projects/aiida-core/en/latest/topics/plugins.html#guidelines-for-plugin-design>)
-* Documentation on {ref}`how to package plugins <aiida:how-to:plugin-codes>`.
+* Documentation on {ref}`how to package plugins <aiida:how-to:plugins-develop>`.
 * Rundown of <a href="https://github.com/aiidateam/aiida-diff#repository-contents" target="_blank"> repository contents of the aiida-diff package</a> (the default output of the plugin cutter)

--- a/docs/sections/creating_plugins/example.md
+++ b/docs/sections/creating_plugins/example.md
@@ -2,7 +2,7 @@
 
 # Interfacing with external codes - Example
 
-**Task:** Follow the instructions on [writing a plugin for an external code](<https://aiida.readthedocs.io/projects/aiida-core/en/latest/howto/plugin_codes.html>).
+**Task:** Follow the instructions on [writing a plugin for an external code](<https://aiida.readthedocs.io/projects/aiida-core/en/v2.0.3/howto/plugin_codes.html>).
 
 **Result:** You will write a Python script with your first `CalcJob` and `Parser` plugin, telling AiiDA how to write inputs and parse outputs for a simple external executable.
 


### PR DESCRIPTION
Fix the redirect link of plugin packaging.

Do we have any plan to release a new version to support this on the tutorial or stick to a specific version for instance `v2.0.3` as we tested? We want to bring the latest features in this tutorial I guess, so I suggest releasing a new version with that support.

