### PR TITLE
Updates for tutorial from advanced workchain sections testing

### DIFF
--- a/docs/sections/clipboard.md
+++ b/docs/sections/clipboard.md
@@ -295,7 +295,7 @@ This can be obtained by using the `get_builder()` method, which is implemented f
 ```{code-block} ipython
 
 In [1]: from aiida.plugins import WorkflowFactory, DataFactory
-   ...: Int = DataFactory('int')
+   ...: Int = DataFactory('core.int')
    ...: MultiplyAddWorkChain = WorkflowFactory('arithmetic.multiply_add')
    ...: builder = MultiplyAddWorkChain.get_builder()
 

--- a/docs/sections/running_processes/reference.md
+++ b/docs/sections/running_processes/reference.md
@@ -71,7 +71,7 @@ To load any data class, we can use AiiDA's `DataFactory` and the *entry point* o
 
 ```{code-block} ipython
 
-In [4]: Dict = DataFactory('dict')
+In [4]: Dict = DataFactory('core.dict')
    ...: new_params = Dict(dict=pw_dict)
 
 ```

--- a/docs/sections/writing_workflows/errors.md
+++ b/docs/sections/writing_workflows/errors.md
@@ -165,7 +165,7 @@ We start by importing the relevant base classes and create a subclass:
 from aiida.engine import BaseRestartWorkChain
 from aiida.plugins import CalculationFactory
 
-ArithmeticAddCalculation = CalculationFactory('arithmetic.add')
+ArithmeticAddCalculation = CalculationFactory('core.arithmetic.add')
 
 class ArithmeticAddBaseWorkChain(BaseRestartWorkChain):
 

--- a/docs/sections/writing_workflows/include/code/multiply_add.py
+++ b/docs/sections/writing_workflows/include/code/multiply_add.py
@@ -14,7 +14,7 @@ from aiida.orm import Code, Int
 from aiida.engine import calcfunction, WorkChain, ToContext
 from aiida.plugins.factories import CalculationFactory
 
-ArithmeticAddCalculation = CalculationFactory("arithmetic.add")
+ArithmeticAddCalculation = CalculationFactory("core.arithmetic.add")
 
 
 @calcfunction

--- a/docs/sections/writing_workflows/include/code/realworld/utils.py
+++ b/docs/sections/writing_workflows/include/code/realworld/utils.py
@@ -3,8 +3,8 @@
 import numpy as np
 from aiida.plugins import CalculationFactory, DataFactory
 
-Dict = DataFactory("dict")
-KpointsData = DataFactory("array.kpoints")
+Dict = DataFactory("core.dict")
+KpointsData = DataFactory("core.array.kpoints")
 PwCalculation = CalculationFactory("quantumespresso.pw")
 
 

--- a/docs/sections/writing_workflows/include/code/realworld/utils.py
+++ b/docs/sections/writing_workflows/include/code/realworld/utils.py
@@ -97,4 +97,5 @@ def plot_eos(eos_pk):
     pl.xlabel("Volume (ang^3)")
     # I take the last value in the list of units assuming units do not change
     pl.ylabel("Energy ({})".format(units))  # pylint: disable=undefined-loop-variable
+    pl.savefig(f"EOS-{eos_pk}.pdf")
     pl.show()

--- a/docs/sections/writing_workflows/include/code/workchain/code_add.yml
+++ b/docs/sections/writing_workflows/include/code/workchain/code_add.yml
@@ -1,7 +1,7 @@
 ---
 label: "add"
 description: "addition code"
-input_plugin: "arithmetic.add"
+input_plugin: "core.arithmetic.add"
 on_computer: true
 remote_abs_path: "/home/fdossantos/codes/aiida-core/aiida/calculations/arithmetic/add.py"
 computer: "localhost"

--- a/docs/sections/writing_workflows/include/data/Si.cif
+++ b/docs/sections/writing_workflows/include/data/Si.cif
@@ -1,0 +1,28 @@
+# generated using pymatgen
+data_Si
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.86697465
+_cell_length_b   3.86697465
+_cell_length_c   3.86697465
+_cell_angle_alpha   60.00000000
+_cell_angle_beta   60.00000000
+_cell_angle_gamma   60.00000000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   Si
+_chemical_formula_sum   Si2
+_cell_volume   40.88829285
+_cell_formula_units_Z   2
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  Si  Si0  1  0.75000000  0.75000000  0.75000000  1
+  Si  Si1  1  0.50000000  0.50000000  0.50000000  1

--- a/docs/sections/writing_workflows/realworld.md
+++ b/docs/sections/writing_workflows/realworld.md
@@ -17,6 +17,48 @@ However, the material is meant be instructive in understanding how to write work
 
 :::
 
+:::{dropdown} Requirements
+
+For the following sections you will need to have already set up the PW code and installed the corresponding pseudopotentials.
+If you already went through the previous sections (in particular, the one about {ref}`running processes <started-basics-calcjobs>`), you should already have these set up.
+
+You can check this by running:
+
+```{code-block} console
+$ verdi code list
+# List of configured codes:
+# (use 'verdi code show CODEID' to see the details)
+* pk 42 - add@localhost
+* pk 74 - pw@localhost # <- this is the relevant code
+```
+
+If you don't have the PW code available, you can set it up by running the following command (you may need to adapt the `--remote-abs-path` or even the `--computer` if you are running in a custom environment):
+
+```{code-block} console
+$ verdi code setup --label pw --computer localhost --remote-abs-path /opt/conda/bin/pw.x --input-plugin quantumespresso.pw --non-interactive
+Success: Code<2> pw@localhost created
+```
+
+On the other hand, you can check the pseudopotentials by running:
+
+```{code-block} console
+aiida-pseudo list
+Label                    Type string         Count
+-----------------------  ------------------  -------
+SSSP/1.1/PBE/efficiency  pseudo.family.sssp  85
+```
+
+And install them with:
+
+```{code-block} console
+aiida-pseudo install sssp
+```
+
+You may also need the dojo pseudopotentials for one of the exercises, which are installed in the exact same way (use the `aiida-pseudo --help` command for further assistance).
+
+:::
+
+
 ## Importing a structure from the COD
 
 First, we'll need the structure of bulk silicon.
@@ -284,6 +326,7 @@ class EquationOfState(WorkChain):
     @classmethod
     def define(cls, spec):
         """Specify inputs and outputs."""
+        super().define(spec)
         # ADD THE DEFINE METHOD
 
     def run_eos(self):
@@ -420,7 +463,7 @@ $ echo "export PYTHONPATH=\$PYTHONPATH:$PWD" >> ~/.bashrc
 
 ```
 
-Next, it is **very important** to restart the daemon, so it can successfully set up the `PYTHONPATH` and find the `EquationOfState` work chain:
+Next, it is **very important** to run `source ~/.bashrc` and restart the daemon, so it can successfully set up the `PYTHONPATH` and find the `EquationOfState` work chain:
 
 ```{code-block} bash
 

--- a/docs/sections/writing_workflows/workchain.md
+++ b/docs/sections/writing_workflows/workchain.md
@@ -430,7 +430,7 @@ How is it different from the `AddWorkChain`?
 The `OutputInputWorkChain` status is just a single line:
 
 ```{code-block} console
-$ verdi process process status <PK>
+$ verdi process status <PK>
 OutputInputWorkChain<1982> Finished [0] [None]
 ```
 

--- a/docs/sections/writing_workflows/workfunction.md
+++ b/docs/sections/writing_workflows/workfunction.md
@@ -12,12 +12,12 @@ In this section, you will learn to:
 
 :::{dropdown} Requirements
 
-For the following sections you will require to have a good structure already loaded in your database.
-If you already went through the previous sections (in particular, the one about {ref}`running processes <started-basics-calcjobs>`), you should already have a Si structure for which we know the following procedures work.
+For the following sections you will require to have a `StructureData` node in your database.
+If you already went through the previous sections (in particular, the one about {ref}`running processes <started-basics-calcjobs>`), you should already have a Si structure for which we know the instructions work fine.
 If you haven't done these, you can get this structure by running:
 
 ```{code-block} console
-$ wget https://aiida-tutorials.readthedocs.io/en/tutorial-2021-intro/_downloads/92e2828a59fc133b391bbf62f0fd1b59/Si.cif
+$ wget https://aiida-tutorials.readthedocs.io/en/tutorial-2022-intro/_downloads/92e2828a59fc133b391bbf62f0fd1b59/Si.cif
 ```
 
 And then import it into your database with the `verdi` CLI.

--- a/docs/sections/writing_workflows/workfunction.md
+++ b/docs/sections/writing_workflows/workfunction.md
@@ -30,8 +30,6 @@ $ verdi data core.structure import ase Si.cif
 Note that the output of `verdi data core.structure import` will probably show a different value for the PK of the structure node you just created: **make a note of this PK**, as you will need to replace it in code snippets later in this tutorial.
 You can also manually download the {{ download }} {download}`Si.cif <include/data/Si.cif>` structure file and copy it in your work environment instead of using `wget`.
 
-:::
-
  (workflows-workfunction-calcfunction)=
 
 ## Calculation functions

--- a/docs/sections/writing_workflows/workfunction.md
+++ b/docs/sections/writing_workflows/workfunction.md
@@ -10,6 +10,28 @@ In this section, you will learn to:
 1. Understand how to add simple Python functions to the provenance.
 2. Learn how to write and launch a simple workflow in AiiDA.
 
+:::{dropdown} Requirements
+
+For the following sections you will require to have a good structure already loaded in your database.
+If you already went through the previous sections (in particular, the one about {ref}`running processes <started-basics-calcjobs>`), you should already have a Si structure for which we know the following procedures work.
+If you haven't done these, you can get this structure by running:
+
+```{code-block} console
+$ wget https://aiida-tutorials.readthedocs.io/en/tutorial-2021-intro/_downloads/92e2828a59fc133b391bbf62f0fd1b59/Si.cif
+```
+
+And then import it into your database with the `verdi` CLI.
+
+:::{code-block} console
+$ verdi data core.structure import ase Si.cif
+  Successfully imported structure Si2 (PK = 1)
+:::
+
+Note that the output of `verdi data core.structure import` will probably show a different value for the PK of the structure node you just created: **make a note of this PK**, as you will need to replace it in code snippets later in this tutorial.
+You can also manually download the {{ download }} {download}`Si.cif <include/data/Si.cif>` structure file and copy it in your work environment instead of using `wget`.
+
+:::
+
  (workflows-workfunction-calcfunction)=
 
 ## Calculation functions
@@ -179,7 +201,7 @@ we can see that the lattice cell vectors are twice as large as initially, which 
 :::{dropdown} **Solution**
 
 In the case of the `multiply` function, the `x` and `y` inputs are simply multiplied using `*`.
-Since `x` and `y` are AiiDA `Int` nodes, this results in a new `Int` node whose value is the product of the two nodes:
+Since `x` and `y` are AiiDA `Int` nodes and the multiplication operator has already been overloaded to handle them, this automatically results in a new `Int` node whose value is the product of the two nodes:
 
 ```{code-block} ipython
 In [12]: Int(2) * Int(3)


### PR DESCRIPTION
Updated some core prefixes and the following modifications:

- Add some requirements to the introduction in case people start in the
middle of the tutorial or for some reason their previous environment is
wiped clean.
- Add small clarification to why multiplication works with aiida Int
type directly.
- Fix typo in `verdi process process status` call
- Add a savefig to the utils method for printing the plot because the
show method was not working for me insite the jupyterlab interface.
- Add the super call to the exercise where they have to fill the define
method because it added an unecessary complexity aspect.
- Add the sourcing of the bashrc between adding the python path and
restarting the daemon.