### PR TITLE
Add instruction for aiidalab-launch

### DIFF
--- a/docs/sections/getting_started/setup.md
+++ b/docs/sections/getting_started/setup.md
@@ -69,7 +69,7 @@ AiiDAlab Launch makes it easy to run AiiDAlab on your own workstation or laptop.
 
 To use AiiDAlab launch you will have to
 
-1. [Install Docker on your workstation or laptop.](https://docs.docker.com/get-docker/)
+1. [Install Docker on your workstation or laptop.](https://docs.docker.com/get-docker/) and [Manage Docker as a non-root user](https://docs.docker.com/engine/install/linux-postinstall/)
 2. Install AiiDAlab launch with [pipx](https://pypa.github.io/pipx/installation/) (**recommended**):
 
    ```console

--- a/docs/sections/getting_started/setup.md
+++ b/docs/sections/getting_started/setup.md
@@ -69,7 +69,7 @@ AiiDAlab Launch makes it easy to run AiiDAlab on your own workstation or laptop.
 
 To use AiiDAlab launch you will have to
 
-1. [Install Docker on your workstation or laptop.](https://docs.docker.com/get-docker/) and [Manage Docker as a non-root user](https://docs.docker.com/engine/install/linux-postinstall/)
+1. [Install Docker on your workstation or laptop](https://docs.docker.com/get-docker/) and [Manage Docker as a non-root user](https://docs.docker.com/engine/install/linux-postinstall/).
 2. Install AiiDAlab launch with [pipx](https://pypa.github.io/pipx/installation/) (**recommended**):
 
    ```console

--- a/docs/sections/getting_started/setup.md
+++ b/docs/sections/getting_started/setup.md
@@ -52,10 +52,6 @@ You can find all instructions on the corresponding GitHub repository:
 
 :::
 
-## Setup using AiiDAlab Launch
-
-AiiDAlab Launch makes it easy to run AiiDAlab on your own workstation or laptop.
-
 ## Setup on your own machine
 
 To run the tutorial on your own machine, you need to install:

--- a/docs/sections/getting_started/setup.md
+++ b/docs/sections/getting_started/setup.md
@@ -52,6 +52,10 @@ You can find all instructions on the corresponding GitHub repository:
 
 :::
 
+## Setup using AiiDAlab Launch
+
+AiiDAlab Launch makes it easy to run AiiDAlab on your own workstation or laptop.
+
 ## Setup on your own machine
 
 To run the tutorial on your own machine, you need to install:
@@ -62,3 +66,36 @@ To run the tutorial on your own machine, you need to install:
 
 ```{note} Version numbers indicate the versions with which the tutorial was tested.
 ```
+
+### using AiiDAlab Launch
+
+AiiDAlab Launch makes it easy to run AiiDAlab on your own workstation or laptop.
+
+To use AiiDAlab launch you will have to
+
+1. [Install Docker on your workstation or laptop.](https://docs.docker.com/get-docker/)
+2. Install AiiDAlab launch with [pipx](https://pypa.github.io/pipx/installation/) (**recommended**):
+
+   ```console
+   pipx install aiidalab-launch
+   ```
+
+   _Or directly with pip (`pip install aiidalab-launch`)._
+
+3. Create a profile for tutorial
+
+    ```console
+    aiidalab-launch profiles add tutorial
+    ```
+
+    It will ask you to edit the profile, since for the tutorial we only need the AiiDA environment, answer `Y` and let's remove the `aiidalab-widgets-base` from the `default_apps` list (or the whole `default_apps` line).
+
+
+3. Start AiiDAlab for `tutorial` profile with
+
+    ```console
+    aiidalab-launch start -p tutorial
+    ```
+4. Follow the instructions on screen to open AiiDAlab in the browser.
+
+See `aiidalab-launch --help` for detailed help.


### PR DESCRIPTION
Since the `aiidalab-widgets-base` migrate to 2.x is not finished, I have to add an instruction to remove it from the default app list.
But it can load the full-stack image and run from it. The aiida version is `2.0.3` but it will be attached with the `full-stack:latest` so not related with this PR.