### PR TITLE
📝 DOCS: Updates for compatibility with AiiDA v2.5.1

### DIFF
--- a/docs/sections/creating_plugins/example.md
+++ b/docs/sections/creating_plugins/example.md
@@ -2,7 +2,7 @@
 
 # Interfacing with external codes - Example
 
-**Task:** Follow the instructions on [writing a plugin for an external code](<https://aiida.readthedocs.io/projects/aiida-core/en/v2.0.3/howto/plugin_codes.html>).
+**Task:** Follow the instructions on [writing a plugin for an external code](<https://aiida.readthedocs.io/projects/aiida-core/en/latest/howto/plugin_codes.html>).
 
 **Result:** You will write a Python script with your first `CalcJob` and `Parser` plugin, telling AiiDA how to write inputs and parse outputs for a simple external executable.
 

--- a/docs/sections/getting_started/basics.md
+++ b/docs/sections/getting_started/basics.md
@@ -415,7 +415,7 @@ For both commands, the *non-interactive* option (`-n`) is added to not prompt fo
 Next, let's set up the code we're going to use for the tutorial:
 
 ```{code-block} console
-$ verdi code setup -L add --on-computer --computer=localhost -P core.arithmetic.add --remote-abs-path=/bin/bash -n
+$ verdi code create core.code.installed -L add --computer=localhost -P core.arithmetic.add --filepath-executable=/bin/bash -n
 ```
 
 This command sets up a code with *label* `add` on the *computer* `localhost`, using the *plugin* `core.arithmetic.add`.
@@ -432,7 +432,7 @@ $ verdi code list
 * pk 1 - add@localhost
 ```
 
-In the output above you can see a the code `add@localhost`, with PK = 1, in the printed list.
+In the output above you can see the code `add@localhost`, with PK = 1, in the printed list.
 Again, in your output you may have other codes listed or a different PK depending on your specific setup, but you should still be able to identify the code by its label.
 The `add@localhost` identifier indicates that the code with label `add` is run on the computer with label `localhost`.
 To see more details about the computer, you can use the following `verdi` command:

--- a/docs/sections/managing_data/querying.ipynb
+++ b/docs/sections/managing_data/querying.ipynb
@@ -61,9 +61,9 @@
     "from aiida.plugins import CalculationFactory, DataFactory\n",
     "\n",
     "PwCalculation = CalculationFactory('quantumespresso.pw')\n",
-    "StructureData = DataFactory('structure')\n",
-    "KpointsData = DataFactory('array.kpoints')\n",
-    "Dict = DataFactory('dict')\n",
+    "StructureData = DataFactory('core.structure')\n",
+    "KpointsData = DataFactory('core.array.kpoints')\n",
+    "Dict = DataFactory('core.dict')\n",
     "UpfData = DataFactory('core.upf')\n",
     "\n",
     "def plot_results(query_res):\n",
@@ -1642,7 +1642,7 @@
     }
    ],
    "source": [
-    "generate_query_graph(query.queryhelp, 'query1.png')\n",
+    "generate_query_graph(query.as_dict(), 'query1.png')\n",
     "Image(filename='query1.png')"
    ]
   },
@@ -1710,7 +1710,7 @@
    "source": [
     "query = QueryBuilder()\n",
     "# Visualize what is going on:\n",
-    "generate_query_graph(query.queryhelp, 'query2.png')\n",
+    "generate_query_graph(query.as_dict(), 'query2.png')\n",
     "Image(filename='query2.png')"
    ]
   },
@@ -2071,7 +2071,7 @@
     ")\n",
     "# Visualize:\n",
     "print(\"Groups:\", ', '.join([g for g, in query.all()]))\n",
-    "generate_query_graph(query.queryhelp, 'query3.png')\n",
+    "generate_query_graph(query.as_dict(), 'query3.png')\n",
     "Image(filename='query3.png')"
    ]
   },

--- a/docs/sections/running_processes/basics.md
+++ b/docs/sections/running_processes/basics.md
@@ -115,7 +115,7 @@ You will notice that the information that goes into the `test_run.in` input file
 * the `UpfData` node with link label `pseudos_Si` contains the data for the *ATOMIC_SPECIES* block (including the pseudopotential file to be copied in the `pseudo_dir`).
 * the `Dict` node with link label `parameters` contains the rest of the data (for the *&CONTROL* and *&SYSTEM* namelists).
 
-Once the inputs files are prepared from these nodes, they are copied into the computer or cluster where the calculation will run.
+Once the input files are prepared from these nodes, they are copied into the computer or cluster where the calculation will run.
 AiiDA immediately generates a `RemoteData` node as part of this submission procedure; this node can be thought as a symbolic link to the remote folder where the files are copied.
 
 The other output nodes are created once the calculation has finished, after the retrieval and parsing steps.
@@ -160,7 +160,7 @@ However, you will still have to set up the code to run it with AiiDA.
 This can be done with:
 
 ```{code-block} console
-$ verdi code setup --label pw --computer localhost --remote-abs-path /opt/conda/bin/pw.x --input-plugin quantumespresso.pw --non-interactive
+$ verdi code create core.code.installed --label pw --computer localhost --filepath-executable /opt/conda/bin/pw.x --default-calc-job-plugin quantumespresso.pw --non-interactive
 Success: Code<2> pw@localhost created
 ```
 
@@ -229,10 +229,10 @@ To get a list of all available [pseudopotentials][pseudopotentials], simply run:
 $ aiida-pseudo list
 Label                                Type string                Count
 -----------------------------------  -------------------------  -------
-SSSP/1.1/PBEsol/precision            pseudo.family.sssp         85
-SSSP/1.1/PBEsol/efficiency           pseudo.family.sssp         85
-SSSP/1.1/PBE/precision               pseudo.family.sssp         85
-SSSP/1.1/PBE/efficiency              pseudo.family.sssp         85
+SSSP/1.3/PBEsol/precision            pseudo.family.sssp         85
+SSSP/1.3/PBEsol/efficiency           pseudo.family.sssp         85
+SSSP/1.3/PBE/precision               pseudo.family.sssp         85
+SSSP/1.3/PBE/efficiency              pseudo.family.sssp         85
 :::
 
 The list of pseudopotential families might differ for you, depending on where you are running the tutorial.
@@ -248,7 +248,7 @@ $ aiida-pseudo install sssp
 Info: downloading selected pseudo potentials archive...  [OK]
 Info: downloading selected pseudo potentials metadata...  [OK]
 Info: unpacking archive and parsing pseudos...  [OK]
-Success: installed `SSSP/1.1/PBE/efficiency` containing 85 pseudo potentials
+Success: installed `SSSP/1.3/PBE/efficiency` containing 85 pseudo potentials
 ```
 
 The output already indicates the process was successful and shows you the label for the new family group.
@@ -362,7 +362,7 @@ We will see more on how to use groups in the module on {ref}`Organising your dat
 
 :::{code-block} ipython
 
-In [5]: pseudo_family = load_group('SSSP/1.1/PBE/efficiency')
+In [5]: pseudo_family = load_group('SSSP/1.3/PBE/efficiency')
 
 :::
 

--- a/docs/sections/running_processes/errors.md
+++ b/docs/sections/running_processes/errors.md
@@ -54,7 +54,7 @@ For the `structure` you can download the following {download}`silicon crystal<in
 If you have already done so previously (as it is used in other tutorial sections), you may want to use that pre-existing node instead of saving a new node with repeated information.
 To do so you may search for its PK by running `verdi data core.structure list` and then use the function `load_node()` to retrieve it.
 
-For the `pseudos` (or [pseudopotentials](https://en.wikipedia.org/wiki/Pseudopotential)), you can use the `SSSP/1.1/PBE/efficiency` family of the `aiida-pseudo` package.
+For the `pseudos` (or [pseudopotentials](https://en.wikipedia.org/wiki/Pseudopotential)), you can use the `SSSP/1.3/PBE/efficiency` family of the `aiida-pseudo` package.
 If you already have it installed, it is enough to use the `load_group()` function and then the `get_pseudos()` method of the loaded pseudo group.
 
 The set of `kpoints` can be simply created by using the methods of the `KpointsData` node class to define a `2x2x2` mesh and store it in a new node.

--- a/docs/sections/running_processes/workflows.md
+++ b/docs/sections/running_processes/workflows.md
@@ -257,10 +257,10 @@ $ aiida-pseudo list
 Label                                Type string                Count
 -----------------------------------  -------------------------  -------
 PseudoDojo/0.4/PBE/SR/standard/upf   pseudo.family.pseudo_dojo  72
-SSSP/1.1/PBEsol/precision            pseudo.family.sssp         85
-SSSP/1.1/PBEsol/efficiency           pseudo.family.sssp         85
-SSSP/1.1/PBE/precision               pseudo.family.sssp         85
-SSSP/1.1/PBE/efficiency              pseudo.family.sssp         85
+SSSP/1.3/PBEsol/precision            pseudo.family.sssp         85
+SSSP/1.3/PBEsol/efficiency           pseudo.family.sssp         85
+SSSP/1.3/PBE/precision               pseudo.family.sssp         85
+SSSP/1.3/PBE/efficiency              pseudo.family.sssp         85
 
 ```
 

--- a/docs/sections/writing_workflows/errors.md
+++ b/docs/sections/writing_workflows/errors.md
@@ -40,7 +40,7 @@ This exit code is used in the `validate_result` step, where the sum produced by 
 
 ```
 
-If the sum is negative, which is unacceptable in this fictitious example, the work chain return the exit code that corresponds to the label `ERROR_NEGATIVE_NUMBER`.
+If the sum is negative, which is unacceptable in this fictitious example, the work chain returns the exit code that corresponds to the label `ERROR_NEGATIVE_NUMBER`.
 Note that you can use the `self.exit_codes` property of the `WorkChain` to quickly retrieve the exit code using the corresponding label.
 Returning an exit code instructs the engine to abort the work chain, and set the corresponding exit status and message on the node in the provenance graph.
 

--- a/docs/sections/writing_workflows/realworld.md
+++ b/docs/sections/writing_workflows/realworld.md
@@ -32,10 +32,10 @@ $ verdi code list
 * pk 74 - pw@localhost # <- this is the relevant code
 ```
 
-If you don't have the PW code available, you can set it up by running the following command (you may need to adapt the `--remote-abs-path` or even the `--computer` if you are running in a custom environment):
+If you don't have the PW code available, you can set it up by running the following command (you may need to adapt the `--filepath-executable` or even the `--computer` if you are running in a custom environment):
 
 ```{code-block} console
-$ verdi code setup --label pw --computer localhost --remote-abs-path /opt/conda/bin/pw.x --input-plugin quantumespresso.pw --non-interactive
+$ verdi code create core.code.installed --label pw --computer localhost --filepath-executable /opt/conda/bin/pw.x --default-calc-job-plugin quantumespresso.pw --non-interactive
 Success: Code<2> pw@localhost created
 ```
 
@@ -45,7 +45,7 @@ On the other hand, you can check the pseudopotentials by running:
 aiida-pseudo list
 Label                    Type string         Count
 -----------------------  ------------------  -------
-SSSP/1.1/PBE/efficiency  pseudo.family.sssp  85
+SSSP/1.3/PBE/efficiency  pseudo.family.sssp  85
 ```
 
 And install them with:
@@ -219,7 +219,7 @@ To run the workflow, we also have to specify the label of the family of pseudopo
 
 ```{code-block} ipython
 
-In [3]: pseudo_family_label = Str('SSSP/1.1/PBE/efficiency')
+In [3]: pseudo_family_label = Str('SSSP/1.3/PBE/efficiency')
 
 ```
 
@@ -477,7 +477,7 @@ Once the daemon has been restarted, it is time to *submit* the `EquationOfState`
 
 In [1]: from eos_workchain import EquationOfState
    ...: from aiida.engine import submit
-   ...: submit(EquationOfState, code=load_code('pw@localhost'), pseudo_family_label=Str('SSSP/1.1/PBE/efficiency'), structure=load_node(pk=<PK>))
+   ...: submit(EquationOfState, code=load_code('pw@localhost'), pseudo_family_label=Str('SSSP/1.3/PBE/efficiency'), structure=load_node(pk=<PK>))
 Out[1]: <WorkChainNode: uuid: 9e5c7c48-a47c-49fc-a8ab-fff081f250ee (pk: 665) (eos.workchain.EquationOfState)>
 
 ```

--- a/docs/sections/writing_workflows/workchain.md
+++ b/docs/sections/writing_workflows/workchain.md
@@ -736,7 +736,7 @@ If not, you can set it up with the instructions in the dropdown below.
 Setting up the `add` code on the `localhost` computer can be done with the following command:
 
 ```{code-block} console
-$ verdi code setup -L add --on-computer --computer=localhost -P core.arithmetic.add --remote-abs-path=/bin/bash -n
+$ verdi code create core.code.installed -L add --computer=localhost -P core.arithmetic.add --filepath-executable=/bin/bash -n
 ```
 
 See the {ref}`calculation jobs section <started-basics-calcjobs>` in the AiiDA basics module for more details.


### PR DESCRIPTION
These minor changes fix issues and deprecation warnings that arose when going through the tutorial with the latest AiiDA v2.5.1. The modifications are mainly:
- Update the `verdi code setup` to `verdi code create` commands
- Update the SSSP version from 1.1 to 1.3 to reflect the change of default in `aiida-pseudo`
- Prepend `core` in the `DataFactory` calls where applicable, as well as `query.queryhelp` -> `query.as_dict()` in the `querying` notebook

One could also update the outputs, for instance, to reflect the change from `Info` to `Report` for the `verdi process` commands, as well as adding the additional information on caching which is now shown to avoid confusion, though it's not really necessary for being able to work through the material.

I understand that this page was initially intended for the AiiDA courses, so it's good to have a frozen version for each edition of the course. Though, as we'd like to eventually integrate this material into the main documentation (see issue 
 aiidateam/aiida-core#6287), I think it's good to have it updated now.

Lastly, a few deprecation warnings remain, for example:
```shell
- aiida/cmdline/groups/dynamic.py:145: AiidaDeprecationWarning: Relying on `_get_cli_options` is deprecated. The options should be defined through a `pydantic.BaseModel` that should be assigned to the `Config` class attribute. (this will be removed in v3)
- aiida/orm/nodes/data/code/legacy.py:42: AiidaDeprecationWarning: The `Code` class is deprecated. To create an instance, use the `aiida.orm.nodes.data.code.installed.InstalledCode` or `aiida.orm.nodes.data.code.portable.PortableCode` for a "remote" or "local" code, respectively. If you are using this class to compare type, e.g. in `isinstance`, use `aiida.orm.nodes.data.code.abstract.AbstractCode`. (this will be removed in v3)
- aiida/orm/nodes/data/code/legacy.py:172: AiidaDeprecationWarning: `Code.get_description` method is deprecated, use the `description` property instead. (this will be removed in v3)
```
however, I think these have to be adressed in the `src`.